### PR TITLE
Add ATMS components

### DIFF
--- a/dump/aux/atms_beamwidth.txt
+++ b/dump/aux/atms_beamwidth.txt
@@ -1,0 +1,36 @@
+# LOC = data/preproc/atms_beamwidth.dat
+# WMO Satellite ID
+224
+# Version identifier
+1
+# Sampling distance (deg)
+1.11
+# Number of channels to modify
+22 
+# Channel, beam width, new width, cutoff, nxaverage, nyaverage, QC dist
+# Note: to use FFT technique, set new width and cutoff as required and set 
+# nxaverage and nyaverage to 0. To use simple averaging set new width to 0.0
+# and use nxaverage and nyaverage (e.g. 3 3 for 3x3 averaging).
+# QC Dist gives number of points around missing value to flag as missing.
+ 1 5.2 3.33 0.4 0 0 11
+ 2 5.2 3.33 0.4 0 0 11
+ 3 2.2 3.33 0.0 0 0  5
+ 4 2.2 3.33 0.0 0 0  5
+ 5 2.2 3.33 0.0 0 0  5 
+ 6 2.2 3.33 0.0 0 0  5 
+ 7 2.2 3.33 0.0 0 0  5 
+ 8 2.2 3.33 0.0 0 0  5 
+ 9 2.2 3.33 0.0 0 0  5 
+10 2.2 3.33 0.0 0 0  5 
+11 2.2 3.33 0.0 0 0  5 
+12 2.2 3.33 0.0 0 0  5 
+13 2.2 3.33 0.0 0 0  5 
+14 2.2 3.33 0.0 0 0  5 
+15 2.2 3.33 0.0 0 0  5 
+16 2.2 3.33 0.0 0 0  5 
+17 1.1 3.33 0.0 0 0  5
+18 1.1 3.33 0.0 0 0  5
+19 1.1 3.33 0.0 0 0  5
+20 1.1 3.33 0.0 0 0  5
+21 1.1 3.33 0.0 0 0  5
+22 1.1 3.33 0.0 0 0  5

--- a/dump/mapping/bufr_atms.py
+++ b/dump/mapping/bufr_atms.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+import sys
+import os
+import argparse
+import time
+import numpy as np
+import bufr
+from pyioda.ioda.Engines.Bufr import Encoder as iodaEncoder 
+from bufr.encoders.netcdf import Encoder as netcdfEncoder 
+from wxflow import Logger
+
+# Initialize Logger
+# Get log level from the environment variable, default to 'INFO it not set
+log_level = os.getenv('LOG_LEVEL', 'INFO')
+logger = Logger('BUFR_atms.py', level=log_level, colored_log=False)
+
+def logging(comm, level, message):
+    """
+    Logs a message to the console or log file, based on the specified logging level.
+
+    This function ensures that logging is only performed by the root process (`rank 0`) 
+    in a distributed computing environment. The function maps the logging level to 
+    appropriate logger methods and defaults to the 'INFO' level if an invalid level is provided.
+
+    Parameters:
+        comm: object
+            The communicator object, typically from a distributed computing framework 
+            (e.g., MPI). It must have a `rank()` method to determine the process rank.
+        level: str
+            The logging level as a string. Supported levels are:
+                - 'DEBUG'
+                - 'INFO'
+                - 'WARNING'
+                - 'ERROR'
+                - 'CRITICAL'
+            If an invalid level is provided, a warning will be logged, and the level 
+            will default to 'INFO'.
+        message: str
+            The message to be logged.
+
+    Behavior:
+        - Logs messages only on the root process (`comm.rank() == 0`).
+        - Maps the provided logging level to a method of the logger object.
+        - Defaults to 'INFO' and logs a warning if an invalid logging level is given.
+        - Supports standard logging levels for granular control over log verbosity.
+
+    Example:
+        >>> logging(comm, 'DEBUG', 'This is a debug message.')
+        >>> logging(comm, 'ERROR', 'An error occurred!')
+
+    Notes:
+        - Ensure that a global `logger` object is configured before using this function.
+        - The `comm` object should conform to MPI-like conventions (e.g., `rank()` method).
+    """
+
+    if comm.rank() == 0:
+        # Define a dictionary to map levels to logger methods
+        log_methods = {
+            'DEBUG': logger.debug,
+            'INFO': logger.info,
+            'WARNING': logger.warning,
+            'ERROR': logger.error,
+            'CRITICAL': logger.critical,
+        }
+
+        # Get the appropriate logging method, default to 'INFO'
+        log_method = log_methods.get(level.upper(), logger.info)
+
+        if log_method == logger.info and level.upper() not in log_methods:
+            # Log a warning if the level is invalid
+            logger.warning(f'log level = {level}: not a valid level --> set to INFO')
+
+        # Call the logging method
+        log_method(message)
+
+def _make_description(mapping_path, update=False):
+
+    description = bufr.encoders.Description(mapping_path)
+
+    return description
+
+def _make_obs(comm, input_path, mapping_path):
+
+    # Get container from mapping file first
+    logging(comm, 'INFO', 'Get container from bufr')
+    container = bufr.Parser(input_path, mapping_path).parse(comm)
+
+    logging(comm, 'DEBUG', f'container list (original): {container.list()}')
+    logging(comm, 'DEBUG', f'all_sub_categories =  {container.all_sub_categories()}')
+    logging(comm, 'DEBUG', f'category map =  {container.get_category_map()}')
+
+    # Add new/derived data into container
+    for cat in container.all_sub_categories():  
+
+        logging(comm, 'DEBUG', f'category = {cat}')
+
+        satid = container.get('variables/satelliteId', cat)
+        if satid.size == 0:
+            logging(comm, 'WARNING', f'category {cat[0]} does not exist in input file')
+
+    # Check
+    logging(comm, 'DEBUG', f'container list (updated): {container.list()}')
+    logging(comm, 'DEBUG', f'all_sub_categories {container.all_sub_categories()}')
+
+    return container
+
+def create_obs_group(input_path, mapping_path, category, env):
+
+    comm = bufr.mpi.Comm(env["comm_name"])
+
+    description = _make_description(mapping_path, update=False)
+
+    # Check the cache for the data and return it if it exists
+    logging(comm, 'DEBUG', f'Check if bufr.DataCache exists? {bufr.DataCache.has(input_path, mapping_path)}')
+    if bufr.DataCache.has(input_path, mapping_path):
+        container = bufr.DataCache.get(input_path, mapping_path)
+        logging(comm, 'INFO', f'Encode {category} from cache')
+        data = iodaEncoder(description).encode(container)[(category,)]
+        logging(comm, 'INFO', f'Mark {category} as finished in the cache')
+        bufr.DataCache.mark_finished(input_path, mapping_path, [category])
+        logging(comm, 'INFO', f'Return the encoded data for {category}')
+        return data
+
+    container = _make_obs(comm, input_path, mapping_path)
+
+    # Gather data from all tasks into all tasks. Each task will have the complete record 
+    logging(comm, 'INFO', f'Gather data from all tasks into all tasks')
+    container.all_gather(comm)
+
+    logging(comm, 'INFO', f'Add container to cache')
+    # Add the container to the cache
+    bufr.DataCache.add(input_path, mapping_path, container.all_sub_categories(), container)
+
+    # Encode the data
+    logging(comm, 'INFO', f'Encode {category}')
+    data = iodaEncoder(description).encode(container)[(category,)]
+
+    logging(comm, 'INFO', f'Mark {category} as finished in the cache')
+    # Mark the data as finished in the cache
+    bufr.DataCache.mark_finished(input_path, mapping_path, [category])
+
+    logging(comm, 'INFO', f'Return the encoded data for {category}')
+    return data
+
+def create_obs_file(input_path, mapping_path, output_path):
+
+    comm = bufr.mpi.Comm("world")
+    container = _make_obs(comm, input_path, mapping_path)
+    container.gather(comm)
+
+    description = _make_description(mapping_path, update=False)
+
+    # Encode the data
+    if comm.rank() == 0:
+        netcdfEncoder(description).encode(container, output_path) 
+
+    logging(comm, 'INFO', f'Return the encoded data')
+
+
+if __name__ == '__main__':
+
+    start_time = time.time()
+
+    bufr.mpi.App(sys.argv)
+    comm = bufr.mpi.Comm("world")
+
+    # Required input arguments as positional arguments
+    parser = argparse.ArgumentParser(description="Convert BUFR to NetCDF using a mapping file.")
+    parser.add_argument('input', type=str, help='Input BUFR file')
+    parser.add_argument('mapping', type=str, help='BUFR2IODA Mapping File')
+    parser.add_argument('output', type=str, help='Output NetCDF file')
+
+    args = parser.parse_args()
+    mapping = args.mapping
+    infile = args.input
+    output = args.output
+
+    create_obs_file(infile, mapping, output)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logging(comm, 'INFO', f'Total running time: {running_time}')

--- a/dump/mapping/bufr_atms.py
+++ b/dump/mapping/bufr_atms.py
@@ -5,8 +5,8 @@ import argparse
 import time
 import numpy as np
 import bufr
-from pyioda.ioda.Engines.Bufr import Encoder as iodaEncoder 
-from bufr.encoders.netcdf import Encoder as netcdfEncoder 
+from pyioda.ioda.Engines.Bufr import Encoder as iodaEncoder
+from bufr.encoders.netcdf import Encoder as netcdfEncoder
 from wxflow import Logger
 
 # Initialize Logger
@@ -19,13 +19,13 @@ def logging(comm, level, message):
     """
     Logs a message to the console or log file, based on the specified logging level.
 
-    This function ensures that logging is only performed by the root process (`rank 0`) 
-    in a distributed computing environment. The function maps the logging level to 
+    This function ensures that logging is only performed by the root process (`rank 0`)
+    in a distributed computing environment. The function maps the logging level to
     appropriate logger methods and defaults to the 'INFO' level if an invalid level is provided.
 
     Parameters:
         comm: object
-            The communicator object, typically from a distributed computing framework 
+            The communicator object, typically from a distributed computing framework
             (e.g., MPI). It must have a `rank()` method to determine the process rank.
         level: str
             The logging level as a string. Supported levels are:
@@ -34,7 +34,7 @@ def logging(comm, level, message):
                 - 'WARNING'
                 - 'ERROR'
                 - 'CRITICAL'
-            If an invalid level is provided, a warning will be logged, and the level 
+            If an invalid level is provided, a warning will be logged, and the level
             will default to 'INFO'.
         message: str
             The message to be logged.
@@ -93,7 +93,7 @@ def _make_obs(comm, input_path, mapping_path):
     logging(comm, 'DEBUG', f'category map =  {container.get_category_map()}')
 
     # Add new/derived data into container
-    for cat in container.all_sub_categories():  
+    for cat in container.all_sub_categories():
 
         logging(comm, 'DEBUG', f'category = {cat}')
 
@@ -127,7 +127,7 @@ def create_obs_group(input_path, mapping_path, category, env):
 
     container = _make_obs(comm, input_path, mapping_path)
 
-    # Gather data from all tasks into all tasks. Each task will have the complete record 
+    # Gather data from all tasks into all tasks. Each task will have the complete record
     logging(comm, 'INFO', f'Gather data from all tasks into all tasks')
     container.all_gather(comm)
 
@@ -157,7 +157,7 @@ def create_obs_file(input_path, mapping_path, output_path):
 
     # Encode the data
     if comm.rank() == 0:
-        netcdfEncoder(description).encode(container, output_path) 
+        netcdfEncoder(description).encode(container, output_path)
 
     logging(comm, 'INFO', f'Return the encoded data')
 

--- a/dump/mapping/bufr_atms.py
+++ b/dump/mapping/bufr_atms.py
@@ -14,6 +14,7 @@ from wxflow import Logger
 log_level = os.getenv('LOG_LEVEL', 'INFO')
 logger = Logger('BUFR_atms.py', level=log_level, colored_log=False)
 
+
 def logging(comm, level, message):
     """
     Logs a message to the console or log file, based on the specified logging level.
@@ -73,11 +74,13 @@ def logging(comm, level, message):
         # Call the logging method
         log_method(message)
 
+
 def _make_description(mapping_path, update=False):
 
     description = bufr.encoders.Description(mapping_path)
 
     return description
+
 
 def _make_obs(comm, input_path, mapping_path):
 
@@ -103,6 +106,7 @@ def _make_obs(comm, input_path, mapping_path):
     logging(comm, 'DEBUG', f'all_sub_categories {container.all_sub_categories()}')
 
     return container
+
 
 def create_obs_group(input_path, mapping_path, category, env):
 
@@ -141,6 +145,7 @@ def create_obs_group(input_path, mapping_path, category, env):
 
     logging(comm, 'INFO', f'Return the encoded data for {category}')
     return data
+
 
 def create_obs_file(input_path, mapping_path, output_path):
 

--- a/dump/mapping/bufr_atms_mapping.yaml
+++ b/dump/mapping/bufr_atms_mapping.yaml
@@ -1,0 +1,197 @@
+bufr:
+  variables:
+    # MetaData
+    timestamp:
+      datetime:
+        year: "*/YEAR"
+        month: "*/MNTH"
+        day: "*/DAYS"
+        hour: "*/HOUR"
+        minute: "*/MINU"
+        second: "*/SECO"
+
+    latitude:
+      query: "*/CLATH"
+
+    longitude:
+      query: "*/CLONH"
+
+    satelliteId:
+      query: "*/SAID"
+
+    satelliteInstrument:
+      query: "*/SIID"
+
+    fieldOfViewNumber:
+      query: "*/FOVN"
+
+    heightOfStation:
+      query: "*/HMSL"
+
+    solarZenithAngle:
+      query: "*/SOZA"
+
+    solarAzimuthAngle:
+      query: "*/SOLAZI"
+
+    sensorZenithAngle:
+      query: "*/SAZA"
+
+    sensorAzimuthAngle:
+      query: "*/BEARAZ"
+
+    sensorScanAngle:
+      sensorScanAngle:
+        fieldOfViewNumber: "*/FOVN"
+        scanStart: -52.725
+        scanStep: 1.110
+        sensor: atms
+
+    sensorChannelNumber:
+      query: "*/ATMSCH/CHNM"
+
+    # ObsValue
+    # Remapped Brightness Temperature
+    remappedBT:
+      remappedBrightnessTemperature:
+        fieldOfViewNumber: "*/FOVN"
+        sensorChannelNumber: "*/ATMSCH/CHNM"
+        brightnessTemperature: "*/ATMSCH/TMANT"
+        obsTime:
+          year: "*/YEAR"
+          month: "*/MNTH"
+          day: "*/DAYS"
+          hour: "*/HOUR"
+          minute: "*/MINU"
+          second: "*/SECO"
+
+  splits:
+    satId:
+      category:
+        variable: satelliteId
+        map:
+          _224: npp
+          _225: n20
+          _226: n21
+
+encoder:
+# type: netcdf
+
+  dimensions:
+    - name: Channel
+      source: variables/sensorChannelNumber
+      path: "*/ATMSCH"
+
+  globals:
+    - name: "platformCommonName"
+      type: string
+      value: "ATMS"
+
+    - name: "platformLongDescription"
+      type: string
+      value: "MTYP 021-203 ATMS ATENNA/BRIGHTNESS TEMPERATURE DATA"
+
+  globals:
+    - name: "platformCommonName"
+      type: string
+      value: "JPSS"
+
+    - name: "platformLongDescription"
+      type: string
+      value: "Joint Polar Satellite System"
+
+    - name: "sensor"
+      type: string
+      value: "Advanced Baseline Imager (ATMS)"
+
+    - name: "source"
+      type: string
+      value: "NCEP BUFR Dump for ATMS brightness temperature data (atms/atmsdb/esatms)"
+
+    - name: "providerFullName"
+      type: string
+      value: "National Environmental Satellite, Data, and Information Service"
+
+    - name: "processingLevel"
+      type: string
+      value: "Level-1B"
+
+    - name: "converter"
+      type: string
+      value: "BUFR"
+
+  variables:
+    # MetaData
+    - name: "MetaData/dateTime"
+      source: variables/timestamp
+      longName: "Datetime"
+      units: "seconds since 1970-01-01T00:00:00Z"
+
+    - name: "MetaData/latitude"
+      source: variables/latitude
+      longName: "Latitude"
+      units: "degree_north"
+      range: [-90, 90]
+
+    - name: "MetaData/longitude"
+      source: variables/longitude
+      longName: "Longitude"
+      units: "degree_east"
+
+    - name: "MetaData/satelliteIdentifier"
+      source: variables/satelliteId
+      longName: "Satellite Identifier"
+
+    - name: "MetaData/satelliteInstrument"
+      source: variables/satelliteInstrument
+      longName: "Satellite Instrument"
+
+    - name: "MetaData/sensorScanPosition"
+      source: variables/fieldOfViewNumber
+      longName: "Field of View Number"
+
+    - name: "MetaData/sensorViewAngle"
+      source: variables/sensorScanAngle
+      longName: "Sensor View Angle"
+      units: "degree"
+
+    - name: "MetaData/heightOfStation"
+      source: variables/heightOfStation
+      longName: "Altitude of Satellite"
+      units: "m"
+
+    - name: "MetaData/solarZenithAngle"
+      source: variables/solarZenithAngle
+      longName: "Solar Zenith Angle"
+      units: "degree"
+      range: [0, 180]
+
+    - name: "MetaData/solarAzimuthAngle"
+      source: variables/solarAzimuthAngle
+      longName: "Solar Azimuth Angle"
+      units: "degree"
+      range: [0, 360]
+
+    - name: "MetaData/sensorZenithAngle"
+      source: variables/sensorZenithAngle
+      longName: "Sensor Zenith Angle"
+      units: "degree"
+      range: [0, 90]
+
+    - name: "MetaData/sensorAzimuthAngle"
+      source: variables/sensorAzimuthAngle
+      longName: "Sensor Azimuth Angle"
+      units: "degree"
+      range: [0, 360]
+
+    - name: "MetaData/sensorChannelNumber"
+      source: variables/sensorChannelNumber
+      longName: "Sensor Channel Number"
+
+    # ObsValue
+    # Remapped Brightness Temperature
+    - name: "ObsValue/brightnessTemperature"
+      source: variables/remappedBT
+      longName: "3-by-3 Averaged Brightness Temperature"
+      units: "K"
+      chunks: [10000, 22]

--- a/dump/mapping/bufr_atms_mapping.yaml
+++ b/dump/mapping/bufr_atms_mapping.yaml
@@ -56,7 +56,7 @@ bufr:
       remappedBrightnessTemperature:
         fieldOfViewNumber: "*/FOVN"
         sensorChannelNumber: "*/ATMSCH/CHNM"
-        brightnessTemperature: "*/ATMSCH/TMANT"
+        brightnessTemperature: "*/ATMSCH/TMBR"
         obsTime:
           year: "*/YEAR"
           month: "*/MNTH"

--- a/dump/mapping/bufr_atms_mapping.yaml
+++ b/dump/mapping/bufr_atms_mapping.yaml
@@ -85,15 +85,6 @@ encoder:
   globals:
     - name: "platformCommonName"
       type: string
-      value: "ATMS"
-
-    - name: "platformLongDescription"
-      type: string
-      value: "MTYP 021-203 ATMS ATENNA/BRIGHTNESS TEMPERATURE DATA"
-
-  globals:
-    - name: "platformCommonName"
-      type: string
       value: "JPSS"
 
     - name: "platformLongDescription"
@@ -106,7 +97,7 @@ encoder:
 
     - name: "source"
       type: string
-      value: "NCEP BUFR Dump for ATMS brightness temperature data (atms/atmsdb/esatms)"
+      value: "NCEP BUFR Dump for ATMS brightness temperature data (atms normal feed)"
 
     - name: "providerFullName"
       type: string

--- a/ush/test/config/bufr_bufr4backend_atms.yaml
+++ b/ush/test/config/bufr_bufr4backend_atms.yaml
@@ -1,0 +1,58 @@
+time window:
+  begin: "2018-04-14T21:00:00Z"
+  end: "2023-12-15T03:00:00Z"
+
+observations:
+- obs space:
+    name: "atms_npp"
+    simulated variables: ['brightnessTemperature']
+    obsdatain:
+      engine:
+        type: bufr 
+        obsfile: "./testinput/2021080100/gdas.t00z.atms.tm00.bufr_d"
+        mapping file: "./bufr_atms_mapping.yaml"
+        category: ["npp"]            # optional (needed if the BUFR mapping defines splits)
+        cache categories:            # optional
+          - ["npp"]
+          - ["n20"]
+          - ["n21"]
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "./testoutput/2021080100/bufr4backend/gdas.t00z.atms_npp.tm00.nc"
+
+- obs space:
+    name: "atms_n20"
+    simulated variables: ['brightnessTemperature']
+    obsdatain:
+      engine:
+        type: bufr 
+        obsfile: "./testinput/2021080100/gdas.t00z.atms.tm00.bufr_d"
+        mapping file: "./bufr_atms_mapping.yaml"
+        category: ["n20"]
+        cache categories:
+          - ["npp"]
+          - ["n20"]
+          - ["n21"]
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "./testoutput/2021080100/bufr4backend/gdas.t00z.atms_n20.tm00.nc"
+
+- obs space:
+    name: "atms_n21"
+    simulated variables: ['brightnessTemperature']
+    obsdatain:
+      engine:
+        type: bufr 
+        obsfile: "./testinput/2021080100/gdas.t00z.atms.tm00.bufr_d"
+        mapping file: "./bufr_atms_mapping.yaml"
+        category: ["n21"]            # optional (needed if the BUFR mapping defines splits)
+        cache categories:            # optional
+          - ["npp"]
+          - ["n20"]
+          - ["n21"]
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: "./testoutput/2021080100/bufr4backend/gdas.t00z.atms_n21.tm00.nc"

--- a/ush/test/config/bufr_bufr4backend_atms.yaml
+++ b/ush/test/config/bufr_bufr4backend_atms.yaml
@@ -1,6 +1,7 @@
 time window:
   begin: "2018-04-14T21:00:00Z"
   end: "2023-12-15T03:00:00Z"
+  bound to include: begin
 
 observations:
 - obs space:

--- a/ush/test/config/bufr_script4backend_atms.yaml
+++ b/ush/test/config/bufr_script4backend_atms.yaml
@@ -1,6 +1,7 @@
 time window:
   begin: "2018-04-14T21:00:00Z"
   end: "2023-12-15T03:00:00Z"
+  bound to include: begin
 
 observations:
   - obs space:
@@ -9,7 +10,7 @@ observations:
       obsdatain:
         engine:
           type: script
-          script file: "bufr_atms.py"
+          script file: "./bufr_atms.py"
           args:
             input_path: "./testinput/2021080100/gdas.t00z.atms.tm00.bufr_d"
             mapping_path: "./bufr_atms_mapping.yaml"
@@ -25,7 +26,7 @@ observations:
       obsdatain:
         engine:
           type: script
-          script file: "bufr_atms.py"
+          script file: "./bufr_atms.py"
           args:
             input_path: "./testinput/2021080100/gdas.t00z.atms.tm00.bufr_d"
             mapping_path: "./bufr_atms_mapping.yaml"
@@ -41,7 +42,7 @@ observations:
       obsdatain:
         engine:
           type: script
-          script file: "bufr_atms.py"
+          script file: "./bufr_atms.py"
           args:
             input_path: "./testinput/2021080100/gdas.t00z.atms.tm00.bufr_d"
             mapping_path: "./bufr_atms_mapping.yaml"

--- a/ush/test/config/bufr_script4backend_atms.yaml
+++ b/ush/test/config/bufr_script4backend_atms.yaml
@@ -1,0 +1,52 @@
+time window:
+  begin: "2018-04-14T21:00:00Z"
+  end: "2023-12-15T03:00:00Z"
+
+observations:
+  - obs space:
+      name: "atms_npp"
+      simulated variables: ["brightnessTemperature"]
+      obsdatain:
+        engine:
+          type: script
+          script file: "bufr_atms.py"
+          args:
+            input_path: "./testinput/2021080100/gdas.t00z.atms.tm00.bufr_d"
+            mapping_path: "./bufr_atms_mapping.yaml"
+            category: "npp" 
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: "./testoutput/2021080100/script4backend/gdas.t00z.atms_npp.tm00.nc"
+
+  - obs space:
+      name: "atms_n20"
+      simulated variables: ["brightnessTemperature"]
+      obsdatain:
+        engine:
+          type: script
+          script file: "bufr_atms.py"
+          args:
+            input_path: "./testinput/2021080100/gdas.t00z.atms.tm00.bufr_d"
+            mapping_path: "./bufr_atms_mapping.yaml"
+            category: "n20" 
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: "./testoutput/2021080100/script4backend/gdas.t00z.atms_n20.tm00.nc"
+
+  - obs space:
+      name: "atms_n21"
+      simulated variables: ["brightnessTemperature"]
+      obsdatain:
+        engine:
+          type: script
+          script file: "bufr_atms.py"
+          args:
+            input_path: "./testinput/2021080100/gdas.t00z.atms.tm00.bufr_d"
+            mapping_path: "./bufr_atms_mapping.yaml"
+            category: "n21" 
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: "./testoutput/2021080100/script4backend/gdas.t00z.atms_n21.tm00.nc"


### PR DESCRIPTION
Add the following for ATMS:
- mapping file
- python script
- test configuration YAML for bufr/script backend
- aux/auxiliary file (atms_beamwidth.txt)

Test all four configurations (bufr2netcdf, script2netcdf, bufr4backend, script4backend) with and without MPI
Output files are consistent between runs w/wo MPI.
