### PR TITLE
Add python coding norm ctest

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,0 +1,6 @@
+[pycodestyle]
+count = False
+ignore = E226,E401,E402,W503
+max-line-length = 160
+statistics = True
+exclude = Experimental

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(SPOC)
+project(spoc)
 
 # Enable testing with CTest
 enable_testing()
@@ -12,7 +12,7 @@ message(STATUS "TOP CMAKE_SOURCE_DIR : ${CMAKE_SOURCE_DIR}")
 message(STATUS "TOP CMAKE_CURRENT_SOURCE_DIR : ${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Register the Python style check as a test
-add_test(NAME spoc_py_lint
+add_test(NAME ${PROJECT_NAME}_python_coding_norms 
          COMMAND ${CMAKE_BINARY_DIR}/bin/spoc_py_lint.sh
 	         ${CMAKE_SOURCE_DIR}/dump/mapping
                  ${CMAKE_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.20)
+project(SPOC)
+
+# Enable testing with CTest
+enable_testing()
+
+# Add subdirectories
+add_subdirectory(tools)
+
+message(STATUS "TOP CMAKE_BINARY_DIR : ${CMAKE_BINARY_DIR}")
+message(STATUS "TOP CMAKE_SOURCE_DIR : ${CMAKE_SOURCE_DIR}")
+message(STATUS "TOP CMAKE_CURRENT_SOURCE_DIR : ${CMAKE_CURRENT_SOURCE_DIR}")
+
+# Register the Python style check as a test
+add_test(NAME spoc_py_lint
+         COMMAND ${CMAKE_BINARY_DIR}/bin/spoc_py_lint.sh
+	         ${CMAKE_SOURCE_DIR}/dump/mapping
+                 ${CMAKE_SOURCE_DIR})
+

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory( build_scripts )

--- a/tools/build_scripts/CMakeLists.txt
+++ b/tools/build_scripts/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+
+list(APPEND _scripts
+  spoc_py_lint.sh)
+
+message(STATUS "TOOLS CMAKE_BINARY_DIR : ${CMAKE_BINARY_DIR}")
+message(STATUS "TOOLS CMAKE_CURRENT_SOURCE_DIR_DIR : ${CMAKE_CURRENT_SOURCE_DIR}")
+
+foreach(_f IN LISTS _scripts)
+  execute_process( COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_SOURCE_DIR}/${_f} ${CMAKE_BINARY_DIR}/bin/${_f} )
+endforeach()

--- a/tools/build_scripts/spoc_py_lint.sh
+++ b/tools/build_scripts/spoc_py_lint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu  # strict mode: stop on error or undefined var
+
+SRC_DIR=${1:-"./"}
+PYCODESTYLE_CFG_PATH=${2:-"./"}
+
+# 1. Validate source directory exists
+if [ ! -d "$SRC_DIR" ]; then
+  echo "ERROR: Source directory not found: $SRC_DIR"
+  exit 1
+fi
+
+# 2. Validate config file exists
+if [ ! -f "$PYCODESTYLE_CFG_PATH/.pycodestyle" ]; then
+  echo "ERROR: .pycodestyle not found in: $PYCODESTYLE_CFG_PATH"
+  exit 1
+fi
+
+echo "Running pycodestyle in: $SRC_DIR"
+echo "Using config: $PYCODESTYLE_CFG_PATH/.pycodestyle"
+
+# 3. Find Python files recursively under SRC_DIR
+PY_FILES=$(find "$SRC_DIR" -name '*.py' -o -name '*.py.in')
+
+if [ -z "$PY_FILES" ]; then
+  echo "No Python files found in: $SRC_DIR"
+  exit 0
+fi
+
+# 4. Run pycodestyle
+pycodestyle -v --config="$PYCODESTYLE_CFG_PATH/.pycodestyle" $PY_FILES
+


### PR DESCRIPTION
Add coding norm ctest for Python.
It works as expected.  However, this capability needs Python's `pycodestyle`
Currently, gdasapp modules are loaded and then run the ctest

**I need help to set test environment.** 

One question:  Do we need this capability in SPOC or we add the coding norms in obsForge? 


```
ctets -VV -R spoc_python_coding_norm
```

```
(gdasapp) orion-login-2[462] eliu$ ctest -VV -R spoc_python_coding_norms
UpdateCTestConfiguration  from :/work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/build/DartConfiguration.tcl
Test project /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: spoc_python_coding_norms

1: Test command: /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/build/bin/spoc_py_lint.sh "/work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping" "/work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc"
1: Test timeout computed to be: 10000000
1: Running pycodestyle in: /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping
1: Using config: /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/.pycodestyle
1: cli configuration: /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/.pycodestyle
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_sfcshp_prepbufr.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_satwnd_amv_seviri.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_amsua.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_satwnd_amv_ahi.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_satwnd_amv_leogeo.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_satwnd_amv_viirs.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_mtiasi.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_adpsfc_prepbufr.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_satwnd_amv_abi.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_atms.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_satwnd_amv_modis.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_satwnd_amv_avhrr.py
1: checking /work/noaa/da/eliu/ORION/EMC-obsForge/obsForge/sorc/spoc/dump/mapping/bufr_sfcsno.py
1/1 Test #1: spoc_python_coding_norms .........   Passed    0.98 sec

The following tests passed:
	spoc_python_coding_norms

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.98 sec

```