### PR TITLE
Add SSMIS mapping file and python scripts

### DIFF
--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -30,15 +30,16 @@ def get_default_nprocs(default=8):
 
        srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py
 
-    2, Run without slurm and tell Python to spawn 12 worker processes via myltiprocessing.Pool 
+    2. Run without slurm and tell Python to spawn 12 worker processes via myltiprocessing.Pool 
 
        export CPUS_PER_TASKS=12
        python bufr_ssmis.py
 
-    :param default: Fallback default if nothing is found.
-    :type default: int
-    :returns: Number of processes to use.
-    :rtype: int
+    Parameters:
+        default: Fallback default if nothing is found.
+
+    Returns:
+        Number of processes to use.
     """
     env_nprocs = os.getenv("CPUS_PER_TASK")
     slurm_nprocs = os.environ.get("SLURM_CPUS_PER_TASK")
@@ -56,20 +57,19 @@ def compute_solar_angles(lat, lon, unix_time):
     """
     Compute solar zenith and azimuth angles for a single point.
 
-    :param lat: Latitude in degrees.
-    :type lat: float
-    :param lon: Longitude in degrees.
-    :type lon: float
-    :param unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
-    :type unix_time: int64
-
-    :returns: A tuple of (zenith angle, azimuth angle).
-    :rtype: tuple of float
+    Parameters:
+        lat: Latitude in degrees.
+        lon: Longitude in degrees.
+        unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
+    Returns:
+        tuple: zenith angle, azimuth angle
     """
+
     dt = datetime.fromtimestamp(int(unix_time), tz=timezone.utc)
     altitude = get_altitude(lat, lon, dt)
     azimuth = get_azimuth(lat, lon, dt)
     zenith = 90.0 - altitude
+
     return zenith, azimuth
 
 
@@ -143,10 +143,9 @@ class BufrSsmisObsBuilder(ObsBuilder):
 
     def _add_satellite_ascend_descent_orbit(self, container, category):
         """
-        Determines if the satellite is in ascending or descending mode based on latitude changes.
-
-        :param ephemeris_data: List of dictionaries with 'latitude' values in order of time.
-        :return: "Ascending" if latitude increases, "Descending" if latitude decreases.
+        Determine satellite orbit type (ascending or descending) based on latitude changes
+        if latitude increases, this is ascending orbit and the orbit type is set to 1
+        if latitude decreases, this is descending orbit and the orbit type is set to -1
         """
 
         satId = container.get('satelliteId', category)
@@ -158,6 +157,7 @@ class BufrSsmisObsBuilder(ObsBuilder):
             return
 
         # Get data from container
+        # ephemeris data - latitude values in order of time
         first_lat = container.get('latitude1',category)
         self.log.debug(f'first_lat min/max = {first_lat.min()} {first_lat.max()}')
         second_lat = container.get('latitude2',category)
@@ -180,18 +180,15 @@ class BufrSsmisObsBuilder(ObsBuilder):
         """
         Compute solar zenith and azimuth angles in parallel using multiprocessing.
 
-        :param latitudes: Array of latitudes in degrees.
-        :type latitudes: numpy.ndarray
-        :param longitudes: Array of longitudes in degrees.
-        :type longitudes: numpy.ndarray
-        :param unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
-        :type unix_times: numpy.ndarray
-        :param nprocs: Number of processes to use. Defaults to the number of CPU cores.
-        :type nprocs: int, optional
+        Parameters:
+            latitudes: Array of latitudes in degrees.
+            longitudes: Array of longitudes in degrees.
+            unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
+            nprocs: Number of processes to use. Defaults to the number of CPU cores.
 
-        :returns: Two arrays: zenith angles and azimuth angles.
-        :rtype: tuple of numpy.ndarray
+        Returns: Two arrays: zenith angles and azimuth angles.
         """
+
         assert len(latitudes) == len(longitudes) == len(unix_times), "Input arrays must be the same length"
 
         if nprocs is None:
@@ -208,10 +205,14 @@ class BufrSsmisObsBuilder(ObsBuilder):
         zenith_angles, azimuth_angles = zip(*results)
         zenith_angles = np.array(zenith_angles)
         azimuth_angles = np.array(azimuth_angles) 
+
         return zenith_angles, azimuth_angles
 
 
     def _add_solar_angles(self, container, category):
+        """
+        Compute and add solar zenith and azimuth angles to container 
+        """
 
         satId = container.get('satelliteId', category)
         if not satId.size:
@@ -229,14 +230,17 @@ class BufrSsmisObsBuilder(ObsBuilder):
         self.log.debug(f'longitudes min/max = {longitudes.min()} {longitudes.max()}')
         self.log.debug(f'unix_times min/max = {unix_times.min()} {unix_times.max()}')
 
+        # Calculate solar angles
         zenith_angles, azimuth_angles = self._compute_solar_angles_parallel(latitudes, longitudes, unix_times)
 
         self.log.debug(f'zenith_angles min/max = {zenith_angles.min()} {zenith_angles.max()}')
         self.log.debug(f'azimuth_angles min/max = {azimuth_angles.min()} {azimuth_angles.max()}')
 
+        # Add solar angles to contained
         paths = container.get_paths('latitude', category)
         self.log.debug(f'paths = {paths}')
         container.add('solarZenithAngle', zenith_angles, paths, category)
         container.add('solarAzimuthAngle', azimuth_angles, paths, category)
+
 
 add_main_functions(BufrSsmisObsBuilder)

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -12,34 +12,42 @@ from bufr.obs_builder import ObsBuilder, add_main_functions
 
 
 def map_path(map_file_name):
+    """
+    Generate the full path to the mapping file.
+
+    :param map_file_name: Name of the mapping file.
+    :type map_file_name: str
+    :return: Full path to the mapping file.
+    :rtype: str
+    """
     script_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(script_dir, map_file_name)
 
 
 def get_default_nprocs(default=8):
     """
-    Determine number of processes to use from CPUS_PER_TASK, SLURM_CPUS_PER_TASK, or fallback.
+    Determine the number of processes to use from environment variables or fallback to a default.
 
-    SLURM_CPUS_PER_TASK - auto-detected from slurm
-    CPU_PER_TASK - input from user
+    Environment Variables:
+        - `SLURM_CPUS_PER_TASK`: Auto-detected from Slurm.
+        - `CPUS_PER_TASK`: Input provided by the user.
 
-    Examples from command line:
-    1. Run with 1 slurm task and reserve 12 CPU cores for this one task.
-       In Python, this will spawn 12 worker processes via multiprocessing.Pool.
-       (SLURM_CPUS_PER_TASK = 12)
+    Examples:
+        1. Run with 1 Slurm task and reserve 12 CPU cores for this one task.
+           This spawns 12 worker processes via `multiprocessing.Pool`.
+           (SLURM_CPUS_PER_TASK = 12)
+           Usage:
+               srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py
 
-       srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py
+        2. Run without Slurm, specifying the number of worker processes.
+           Usage:
+               export CPUS_PER_TASK=12
+               python bufr_ssmis.py
 
-    2. Run without slurm and tell Python to spawn 12 worker processes via myltiprocessing.Pool.
-
-       export CPUS_PER_TASKS=12
-       python bufr_ssmis.py
-
-    Parameters:
-        default: Fallback default if nothing is found.
-
-    Returns:
-        Number of processes to use.
+    :param default: Fallback default if environment variables are not set. Defaults to 8.
+    :type default: int
+    :return: Number of processes to use.
+    :rtype: int
     """
     env_nprocs = os.getenv("CPUS_PER_TASK")
     slurm_nprocs = os.environ.get("SLURM_CPUS_PER_TASK")
@@ -55,16 +63,17 @@ def get_default_nprocs(default=8):
 
 def compute_solar_angles(lat, lon, unix_time):
     """
-    Compute solar zenith and azimuth angles for a single point.
+    Compute solar zenith and azimuth angles for a geographical point.
 
-    Parameters:
-        lat: Latitude in degrees.
-        lon: Longitude in degrees.
-        unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
-    Returns:
-        tuple: zenith angle, azimuth angle
+    :param lat: Latitude in degrees.
+    :type lat: float
+    :param lon: Longitude in degrees.
+    :type lon: float
+    :param unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
+    :type unix_time: int
+    :return: Tuple containing zenith angle and azimuth angle (in degrees).
+    :rtype: tuple(float, float)
     """
-
     dt = datetime.fromtimestamp(int(unix_time), tz=timezone.utc)
     altitude = get_altitude(lat, lon, dt)
     azimuth = get_azimuth(lat, lon, dt)
@@ -77,21 +86,39 @@ MAPPING_PATH = map_path('bufr_ssmis.yaml')
 
 
 class BufrSsmisObsBuilder(ObsBuilder):
+    """
+    Builder class for processing BUFR SSMIS observations.
+
+    This class extends the `ObsBuilder` and provides methods to construct
+    observation data, add derived variables, and manage mapping configurations.
+    """
+
     def __init__(self):
+        """
+        Initialize the BufrSsmisObsBuilder with the mapping path and log name.
+        """
         super().__init__(MAPPING_PATH, log_name=os.path.basename(__file__))
 
     def make_obs(self, comm, input_path):
-        # Get container from mapping file first
+        """
+        Create observations and add derived data to the observation container.
+
+        :param comm: Communication object for distributed processing.
+        :type comm: obj
+        :param input_path: Path to the input file.
+        :type input_path: str
+        :return: Updated observation container.
+        :rtype: obj
+        """
         self.log.info('Get container from bufr')
         container = super().make_obs(comm, input_path)
 
         self.log.debug(f'container list (original): {container.list()}')
-        self.log.debug(f'all_sub_categories =  {container.all_sub_categories()}')
-        self.log.debug(f'category map =  {container.get_category_map()}')
+        self.log.debug(f'all_sub_categories = {container.all_sub_categories()}')
+        self.log.debug(f'category map = {container.get_category_map()}')
 
         # Add new/derived data into container
         for cat in container.all_sub_categories():
-
             self.log.debug(f'category = {cat}')
 
             satId = container.get('satelliteId', cat)
@@ -107,44 +134,18 @@ class BufrSsmisObsBuilder(ObsBuilder):
 
         return container
 
-    def _make_description(self):
-        description = super()._make_description()
-        self._add_solar_angles_descriptions(description)
-        self._add_satellite_ascend_descend_orbit_descriptions(description)
-
-        return description
-
-    def _add_solar_angles_descriptions(self, description):
-        description.add_variables([
-            {
-                'name': 'MetaData/solarZenithAngle',
-                'source': 'solarZenithAngle',
-                'units': 'degree',
-                'longName': 'Solar Zenith Angle',
-            },
-            {
-                'name': 'MetaData/solarAzimuthAngle',
-                'source': 'solarAzimuthAngle',
-                'units': 'degree',
-                'longName': 'Solar Azimuth Angle',
-            }])
-
-    def _add_satellite_ascend_descend_orbit_descriptions(self, description):
-        description.add_variables([
-            {
-                'name': 'MetaData/satelliteAscendingFlag',
-                'source': 'satelliteAscendingFlag',
-                'units': '1',
-                'longName': 'Satellite Ascending/Descending Orbit Flag (Ascend:1; Descend:-1)',
-            }])
-
     def _add_satellite_ascend_descent_orbit(self, container, category):
         """
-        Determine satellite orbit type (ascending or descending) based on latitude changes
-        if latitude increases, this is ascending orbit and the orbit type is set to 1
-        if latitude decreases, this is descending orbit and the orbit type is set to -1
-        """
+        Determine satellite orbit type (ascending or descending) based on latitude changes.
 
+        If the latitude increases, the orbit is ascending (flag = 1).
+        If the latitude decreases, the orbit is descending (flag = -1).
+
+        :param container: Observation data container.
+        :type container: obj
+        :param category: Observation category.
+        :type category: obj
+        """
         satId = container.get('satelliteId', category)
 
         if not satId.size:
@@ -154,37 +155,31 @@ class BufrSsmisObsBuilder(ObsBuilder):
             return
 
         # Get data from container
-        # ephemeris data - latitude values in order of time
         first_lat = container.get('latitude1', category)
-        self.log.debug(f'first_lat min/max = {first_lat.min()} {first_lat.max()}')
         second_lat = container.get('latitude2', category)
-        self.log.debug(f'second_lat min/max = {second_lat.min()} {second_lat.max()}')
         fovn = container.get('fieldOfViewNumber', category)
-        self.log.debug(f'fovn min/max = {fovn.min()} {fovn.max()}')
 
         # Determine ascending/descending mode
-        # Compare latitude between the first and second records
         orbit = np.where(second_lat > first_lat, 1, -1).astype(np.int32)
 
-        self.log.debug(f'orbit min/max = {orbit.min()} {orbit.max()}')
-
         paths = container.get_paths('fieldOfViewNumber', category)
-        self.log.debug(f'paths = {paths}')
         container.add('satelliteAscendingFlag', orbit, paths, category)
 
     def _compute_solar_angles_parallel(self, latitudes, longitudes, unix_times, nprocs=None):
         """
         Compute solar zenith and azimuth angles in parallel using multiprocessing.
 
-        Parameters:
-            latitudes: Array of latitudes in degrees.
-            longitudes: Array of longitudes in degrees.
-            unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
-            nprocs: Number of processes to use. Defaults to the number of CPU cores.
-
-        Returns: Two arrays: zenith angles and azimuth angles.
+        :param latitudes: Array of latitudes in degrees.
+        :type latitudes: numpy.ndarray
+        :param longitudes: Array of longitudes in degrees.
+        :type longitudes: numpy.ndarray
+        :param unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
+        :type unix_times: numpy.ndarray
+        :param nprocs: Number of processes to use. If None, defaults to the number of CPU cores.
+        :type nprocs: int, optional
+        :return: Two arrays containing zenith angles and azimuth angles, respectively.
+        :rtype: tuple(numpy.ndarray, numpy.ndarray)
         """
-
         assert len(latitudes) == len(longitudes) == len(unix_times), "Input arrays must be the same length"
 
         if nprocs is None:
@@ -192,50 +187,11 @@ class BufrSsmisObsBuilder(ObsBuilder):
 
         args_list = list(zip(latitudes, longitudes, unix_times))
 
-        self.log.debug(f'Using {nprocs} processes to compute solar angles.')
-
         with Pool(nprocs) as pool:
             results = pool.starmap(compute_solar_angles, args_list)
 
-        self.log.debug(f'Using {nprocs} processes to compute solar angles --- done')
         zenith_angles, azimuth_angles = zip(*results)
-        zenith_angles = np.array(zenith_angles)
-        azimuth_angles = np.array(azimuth_angles)
-
-        return zenith_angles, azimuth_angles
-
-    def _add_solar_angles(self, container, category):
-        """
-        Compute and add solar zenith and azimuth angles to container
-        """
-
-        satId = container.get('satelliteId', category)
-        if not satId.size:
-            paths = container.get_paths('latitude', category)
-            dummy = container.get('latitude', category)
-            container.add('solarZenithAngle', dummy, paths, category)
-            container.add('solarAzimuthAngle', dummy, paths, category)
-            return
-
-        # Prepare input arrays
-        unix_times = container.get('timestamp', category)
-        latitudes = container.get('latitude', category)
-        longitudes = container.get('longitude', category)
-        self.log.debug(f'latitudes min/max = {latitudes.min()} {latitudes.max()}')
-        self.log.debug(f'longitudes min/max = {longitudes.min()} {longitudes.max()}')
-        self.log.debug(f'unix_times min/max = {unix_times.min()} {unix_times.max()}')
-
-        # Calculate solar angles
-        zenith_angles, azimuth_angles = self._compute_solar_angles_parallel(latitudes, longitudes, unix_times)
-
-        self.log.debug(f'zenith_angles min/max = {zenith_angles.min()} {zenith_angles.max()}')
-        self.log.debug(f'azimuth_angles min/max = {azimuth_angles.min()} {azimuth_angles.max()}')
-
-        # Add solar angles to contained
-        paths = container.get_paths('latitude', category)
-        self.log.debug(f'paths = {paths}')
-        container.add('solarZenithAngle', zenith_angles, paths, category)
-        container.add('solarAzimuthAngle', azimuth_angles, paths, category)
+        return np.array(zenith_angles), np.array(azimuth_angles)
 
 
 add_main_functions(BufrSsmisObsBuilder)

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -9,7 +9,6 @@ from multiprocessing import Pool, cpu_count
 
 import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions
-from bufr.obs_builder import ObsBuilder, add_main_functions
 
 
 def map_path(map_file_name):

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -12,6 +12,15 @@ from bufr.obs_builder import ObsBuilder, add_main_functions
 
 
 def map_path(map_file_name):
+    """
+    Get the absolute path to a mapping file.
+
+    :param map_file_name: Name of the mapping file.
+    :type map_file_name: str
+    :return: Absolute path to the mapping file.
+    :rtype: str
+    """
+
     script_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(script_dir, map_file_name)
 
@@ -90,6 +99,11 @@ class BufrSsmisObsBuilder(ObsBuilder):
     """
 
     def __init__(self):
+        """
+        Initialize the BufrSsmisObsBuilder class.
+        Inherits from ObsBuilder and sets up the mapping path and logger.
+        """
+
         super().__init__(MAPPING_PATH, log_name=os.path.basename(__file__))
 
     def make_obs(self, comm, input_path):
@@ -132,6 +146,13 @@ class BufrSsmisObsBuilder(ObsBuilder):
         return container
 
     def _make_description(self):
+        """
+        Create a description of the observations.
+
+        :return: Observation description.
+        :rtype: Description
+        """
+
         description = super()._make_description()
         self._add_solar_angles_descriptions(description)
         self._add_satellite_ascend_descend_orbit_descriptions(description)
@@ -139,6 +160,13 @@ class BufrSsmisObsBuilder(ObsBuilder):
         return description
 
     def _add_solar_angles_descriptions(self, description):
+        """
+        Add solar angle descriptions to the observation metadata.
+
+        :param description: Observation description container.
+        :type description: Description
+        """
+
         description.add_variables([
             {
                 'name': 'MetaData/solarZenithAngle',
@@ -154,6 +182,13 @@ class BufrSsmisObsBuilder(ObsBuilder):
             }])
 
     def _add_satellite_ascend_descend_orbit_descriptions(self, description):
+        """
+        Add satellite orbit descriptions to the observation metadata.
+
+        :param description: Observation description container.
+        :type description: Description
+        """
+
         description.add_variables([
             {
                 'name': 'MetaData/satelliteAscendingFlag',
@@ -274,4 +309,5 @@ class BufrSsmisObsBuilder(ObsBuilder):
         container.add('solarAzimuthAngle', azimuth_angles, paths, category)
 
 
+# Add main functions create_obs_file or create_obs_group
 add_main_functions(BufrSsmisObsBuilder)

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -12,15 +12,6 @@ from bufr.obs_builder import ObsBuilder, add_main_functions
 
 
 def map_path(map_file_name):
-    """
-    Get the absolute path to a mapping file.
-
-    :param map_file_name: Name of the mapping file.
-    :type map_file_name: str
-    :return: Absolute path to the mapping file.
-    :rtype: str
-    """
-
     script_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(script_dir, map_file_name)
 
@@ -99,26 +90,9 @@ class BufrSsmisObsBuilder(ObsBuilder):
     """
 
     def __init__(self):
-        """
-        Initialize the BufrSsmisObsBuilder class.
-
-        Inherits from ObsBuilder and sets up the mapping path and logger.
-        """
-
         super().__init__(MAPPING_PATH, log_name=os.path.basename(__file__))
 
     def make_obs(self, comm, input_path):
-        """
-        Generate observations from BUFR data.
-
-        :param comm: MPI communicator for parallel processing.
-        :type comm: MPI.Comm
-        :param input_path: Path to the input BUFR file.
-        :type input_path: str
-
-        :return: Container with generated observations.
-        :rtype: Container
-        """
 
         # Get container from mapping file first
         self.log.info('Get container from bufr')
@@ -147,26 +121,12 @@ class BufrSsmisObsBuilder(ObsBuilder):
         return container
 
     def _make_description(self):
-        """
-        Create a description of the observations.
-
-        :return: Observation description.
-        :rtype: Description
-        """
-
         description = super()._make_description()
         self._add_new_variable_descriptions(description)
 
         return description
 
     def _add_new_variable_descriptions(self, description):
-        """
-        Add solar angle and orbit flag descriptions to the observation metadata.
-
-        :param description: Observation description container.
-        :type description: Description
-        """
-
         description.add_variables([
             {
                 'name': 'MetaData/satelliteAscendingFlag',

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -20,17 +20,17 @@ def get_default_nprocs(default=8):
     """
     Determine number of processes to use from CPUS_PER_TASK, SLURM_CPUS_PER_TASK, or fallback.
 
-    SLURM_CPUS_PER_TASK - auto-detected from slurm 
-    CPU_PER_TASK - input from user 
+    SLURM_CPUS_PER_TASK - auto-detected from slurm
+    CPU_PER_TASK - input from user
 
     Examples from command line:
-    1. Run with 1 slurm task and reserve 12 CPU cores for this one task
-       In Python, this will spawn 12 worker processes via multiprocessing.Pool
+    1. Run with 1 slurm task and reserve 12 CPU cores for this one task.
+       In Python, this will spawn 12 worker processes via multiprocessing.Pool.
        (SLURM_CPUS_PER_TASK = 12)
 
        srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py
 
-    2. Run without slurm and tell Python to spawn 12 worker processes via myltiprocessing.Pool 
+    2. Run without slurm and tell Python to spawn 12 worker processes via myltiprocessing.Pool.
 
        export CPUS_PER_TASKS=12
        python bufr_ssmis.py
@@ -84,27 +84,27 @@ class BufrSsmisObsBuilder(ObsBuilder):
         # Get container from mapping file first
         self.log.info('Get container from bufr')
         container = super().make_obs(comm, input_path)
-    
+
         self.log.debug(f'container list (original): {container.list()}')
         self.log.debug(f'all_sub_categories =  {container.all_sub_categories()}')
         self.log.debug(f'category map =  {container.get_category_map()}')
-    
+
         # Add new/derived data into container
         for cat in container.all_sub_categories():
-    
+
             self.log.debug(f'category = {cat}')
 
             satId = container.get('satelliteId', cat)
             if not np.any(satId):
                 self.log.warning(f'category {cat[0]} does not exist in input file')
 
-            self._add_solar_angles(container, cat) 
-            self._add_satellite_ascend_descent_orbit(container, cat) 
+            self._add_solar_angles(container, cat)
+            self._add_satellite_ascend_descent_orbit(container, cat)
 
         # Check
         self.log.debug(f'container list (updated): {container.list()}')
         self.log.debug(f'all_sub_categories {container.all_sub_categories()}')
-    
+
         return container
 
     def _make_description(self):
@@ -113,7 +113,6 @@ class BufrSsmisObsBuilder(ObsBuilder):
         self._add_satellite_ascend_descend_orbit_descriptions(description)
 
         return description
-
 
     def _add_solar_angles_descriptions(self, description):
         description.add_variables([
@@ -130,7 +129,6 @@ class BufrSsmisObsBuilder(ObsBuilder):
                 'longName': 'Solar Azimuth Angle',
             }])
 
-
     def _add_satellite_ascend_descend_orbit_descriptions(self, description):
         description.add_variables([
             {
@@ -139,7 +137,6 @@ class BufrSsmisObsBuilder(ObsBuilder):
                 'units': '1',
                 'longName': 'Satellite Ascending/Descending Orbit Flag (Ascend:1; Descend:-1)',
             }])
-
 
     def _add_satellite_ascend_descent_orbit(self, container, category):
         """
@@ -158,11 +155,11 @@ class BufrSsmisObsBuilder(ObsBuilder):
 
         # Get data from container
         # ephemeris data - latitude values in order of time
-        first_lat = container.get('latitude1',category)
+        first_lat = container.get('latitude1', category)
         self.log.debug(f'first_lat min/max = {first_lat.min()} {first_lat.max()}')
-        second_lat = container.get('latitude2',category)
+        second_lat = container.get('latitude2', category)
         self.log.debug(f'second_lat min/max = {second_lat.min()} {second_lat.max()}')
-        fovn = container.get('fieldOfViewNumber',category)
+        fovn = container.get('fieldOfViewNumber', category)
         self.log.debug(f'fovn min/max = {fovn.min()} {fovn.max()}')
 
         # Determine ascending/descending mode
@@ -174,7 +171,6 @@ class BufrSsmisObsBuilder(ObsBuilder):
         paths = container.get_paths('fieldOfViewNumber', category)
         self.log.debug(f'paths = {paths}')
         container.add('satelliteAscendingFlag', orbit, paths, category)
-
 
     def _compute_solar_angles_parallel(self, latitudes, longitudes, unix_times, nprocs=None):
         """
@@ -204,14 +200,13 @@ class BufrSsmisObsBuilder(ObsBuilder):
         self.log.debug(f'Using {nprocs} processes to compute solar angles --- done')
         zenith_angles, azimuth_angles = zip(*results)
         zenith_angles = np.array(zenith_angles)
-        azimuth_angles = np.array(azimuth_angles) 
+        azimuth_angles = np.array(azimuth_angles)
 
         return zenith_angles, azimuth_angles
 
-
     def _add_solar_angles(self, container, category):
         """
-        Compute and add solar zenith and azimuth angles to container 
+        Compute and add solar zenith and azimuth angles to container
         """
 
         satId = container.get('satelliteId', category)
@@ -222,7 +217,7 @@ class BufrSsmisObsBuilder(ObsBuilder):
             container.add('solarAzimuthAngle', dummy, paths, category)
             return
 
-        # Prepare input arrays 
+        # Prepare input arrays
         unix_times = container.get('timestamp', category)
         latitudes = container.get('latitude', category)
         longitudes = container.get('longitude', category)

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -5,8 +5,8 @@ import numpy.ma as ma
 from multiprocessing import Pool, cpu_count
 
 import bufr
-from bufr.obs_builder import ObsBuilder, add_main_functions, map_path, get_default_nprocs
-from bufr.transforms.geometry import compute_solar_angles
+from bufr.obs_builder import ObsBuilder, add_main_functions, map_path, nprocs_per_task
+from bufr.transforms import compute_solar_angles
 
 
 MAPPING_PATH = map_path('bufr_ssmis.yaml')
@@ -138,7 +138,7 @@ class BufrSsmisObsBuilder(ObsBuilder):
         assert len(latitudes) == len(longitudes) == len(unix_times), "Input arrays must be the same length"
 
         if nprocs is None:
-            nprocs = get_default_nprocs()
+            nprocs = nprocs_per_task()
 
         args_list = list(zip(latitudes, longitudes, unix_times))
 

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -19,17 +19,32 @@ def map_path(map_file_name):
 
 def get_default_nprocs(default=8):
     """
-    Determine number of processes to use from SOLAR_ANGLE_NPROCS, SLURM_CPUS_PER_TASK, or fallback.
+    Determine number of processes to use from CPUS_PER_TASK, SLURM_CPUS_PER_TASK, or fallback.
+
+    SLURM_CPUS_PER_TASK - auto-detected from slurm 
+    CPU_PER_TASK - input from user 
+
+    Examples from command line:
+    1. Run with 1 slurm task and reserve 12 CPU cores for this one task
+       In Python, this will spawn 12 worker processes via multiprocessing.Pool
+       (SLURM_CPUS_PER_TASK = 12)
+
+       srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py
+
+    2, Run without slurm and tell Python to spawn 12 worker processes via myltiprocessing.Pool 
+
+       export CPUS_PER_TASKS=12
+       python bufr_ssmis.py
 
     :param default: Fallback default if nothing is found.
     :type default: int
     :returns: Number of processes to use.
     :rtype: int
     """
-    env_nprocs = os.getenv("SOLAR_ANGLE_NPROCS")
+    env_nprocs = os.getenv("CPUS_PER_TASK")
     slurm_nprocs = os.environ.get("SLURM_CPUS_PER_TASK")
 
-    print(f"SOLAR_ANGLE_NPROCS={env_nprocs}, SLURM_CPUS_PER_TASK={slurm_nprocs}")
+    print(f"CPUS_PER_TASK={env_nprocs}, SLURM_CPUS_PER_TASK={slurm_nprocs}")
 
     try:
         return int(env_nprocs or slurm_nprocs or default)
@@ -186,10 +201,8 @@ class BufrSsmisObsBuilder(ObsBuilder):
             nprocs = get_default_nprocs()
 
         args_list = list(zip(latitudes, longitudes, unix_times))
-#       nprocs = nprocs or cpu_count()
 
         self.log.debug(f'Using {nprocs} processes to compute solar angles.')
-        self.log.debug(f'Using {cpu_count()} processes to compute solar angles.')
 
         with Pool(nprocs) as pool:
             results = pool.starmap(compute_solar_angles, args_list)

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+import os
+import numpy as np
+import numpy.ma as ma
+import pytz
+from pysolar.solar import get_altitude, get_azimuth
+from datetime import datetime, timezone
+from multiprocessing import Pool, cpu_count
+
+import bufr
+from bufr.obs_builder import ObsBuilder, add_main_functions
+from bufr.obs_builder import ObsBuilder, add_main_functions
+
+
+def map_path(map_file_name):
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(script_dir, map_file_name)
+
+
+def get_default_nprocs(default=8):
+    """
+    Determine number of processes to use from SOLAR_ANGLE_NPROCS, SLURM_CPUS_PER_TASK, or fallback.
+
+    :param default: Fallback default if nothing is found.
+    :type default: int
+    :returns: Number of processes to use.
+    :rtype: int
+    """
+    env_nprocs = os.getenv("SOLAR_ANGLE_NPROCS")
+    slurm_nprocs = os.environ.get("SLURM_CPUS_PER_TASK")
+
+    print(f"SOLAR_ANGLE_NPROCS={env_nprocs}, SLURM_CPUS_PER_TASK={slurm_nprocs}")
+
+    try:
+        return int(env_nprocs or slurm_nprocs or default)
+    except ValueError:
+        print(f"[WARN] Invalid environment variable value. Falling back to default: {default}")
+        return default
+
+
+def compute_solar_angles(lat, lon, unix_time):
+    """
+    Compute solar zenith and azimuth angles for a single point.
+
+    :param lat: Latitude in degrees.
+    :type lat: float
+    :param lon: Longitude in degrees.
+    :type lon: float
+    :param unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
+    :type unix_time: int64
+
+    :returns: A tuple of (zenith angle, azimuth angle).
+    :rtype: tuple of float
+    """
+    dt = datetime.fromtimestamp(int(unix_time), tz=timezone.utc)
+    altitude = get_altitude(lat, lon, dt)
+    azimuth = get_azimuth(lat, lon, dt)
+    zenith = 90.0 - altitude
+    return zenith, azimuth
+
+
+MAPPING_PATH = map_path('bufr_ssmis.yaml')
+
+
+class BufrSsmisObsBuilder(ObsBuilder):
+    def __init__(self):
+        super().__init__(MAPPING_PATH, log_name=os.path.basename(__file__))
+
+    def make_obs(self, comm, input_path):
+        # Get container from mapping file first
+        self.log.info('Get container from bufr')
+        container = super().make_obs(comm, input_path)
+    
+        self.log.debug(f'comm rank : {comm.rank()}')
+        self.log.debug(f'comm size : {comm.size()}')
+        self.log.debug(f'container list (original): {container.list()}')
+        self.log.debug(f'all_sub_categories =  {container.all_sub_categories()}')
+        self.log.debug(f'category map =  {container.get_category_map()}')
+    
+        # Add new/derived data into container
+        for cat in container.all_sub_categories():
+    
+            self.log.debug(f'category = {cat}')
+
+            satId = container.get('satelliteId', cat)
+            if not np.any(satId):
+                self.log.warning(f'category {cat[0]} does not exist in input file')
+
+            self._add_solar_angles(container, cat) 
+            self._add_satellite_ascend_descent_orbit(container, cat) 
+
+        # Check
+        self.log.debug(f'container list (updated): {container.list()}')
+        self.log.debug(f'all_sub_categories {container.all_sub_categories()}')
+    
+        return container
+
+    def _make_description(self):
+        description = super()._make_description()
+        self._add_solar_angles_descriptions(description)
+        self._add_satellite_ascend_descend_orbit_descriptions(description)
+
+        return description
+
+
+    def _add_solar_angles_descriptions(self, description):
+        description.add_variables([
+            {
+                'name': 'MetaData/solarZenithAngle',
+                'source': 'solarZenithAngle',
+                'units': 'degree',
+                'longName': 'Solar Zenith Angle)',
+            },
+            {
+                'name': 'MetaData/solarAzimuthAngle',
+                'source': 'solarAzimuthAngle',
+                'units': 'degree',
+                'longName': 'Solar Azimuth Angle)',
+            }])
+
+
+    def _add_satellite_ascend_descend_orbit_descriptions(self, description):
+        description.add_variables([
+            {
+                'name': 'MetaData/satelliteAscendingFlag',
+                'source': 'satelliteAscendingFlag',
+                'units': '1',
+                'longName': 'Satellite Ascending/Descending Orbit Flag (Ascend:1; Descend:-1)',
+            }])
+
+
+    def _add_satellite_ascend_descent_orbit(self, container, category):
+        """
+        Determines if the satellite is in ascending or descending mode based on latitude changes.
+
+        :param ephemeris_data: List of dictionaries with 'latitude' values in order of time.
+        :return: "Ascending" if latitude increases, "Descending" if latitude decreases.
+        """
+
+        satId = container.get('satelliteId', category)
+
+        if not satId.size:
+            paths = container.get_paths('fieldOfViewNumber', category)
+            dummy = container.get('fieldOfViewNumber', category)
+            container.add('satelliteAscendingFlag', dummy, paths, category)
+            return
+
+        # Get data from container
+        first_lat = container.get('latitude1',category)
+        self.log.debug(f'first_lat min/max = {first_lat.min()} {first_lat.max()}')
+        second_lat = container.get('latitude2',category)
+        self.log.debug(f'second_lat min/max = {second_lat.min()} {second_lat.max()}')
+        fovn = container.get('fieldOfViewNumber',category)
+        self.log.debug(f'fovn min/max = {fovn.min()} {fovn.max()}')
+
+        # Determine ascending/descending mode
+        # Compare latitude between the first and second records
+        orbit = np.where(second_lat > first_lat, 1, -1).astype(np.int32)
+
+        self.log.debug(f'orbit min/max = {orbit.min()} {orbit.max()}')
+
+        paths = container.get_paths('fieldOfViewNumber', category)
+        self.log.debug(f'paths = {paths}')
+        container.add('satelliteAscendingFlag', orbit, paths, category)
+
+
+    def _compute_solar_angles_parallel(self, latitudes, longitudes, unix_times, nprocs=None):
+        """
+        Compute solar zenith and azimuth angles in parallel using multiprocessing.
+
+        :param latitudes: Array of latitudes in degrees.
+        :type latitudes: numpy.ndarray
+        :param longitudes: Array of longitudes in degrees.
+        :type longitudes: numpy.ndarray
+        :param unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
+        :type unix_times: numpy.ndarray
+        :param nprocs: Number of processes to use. Defaults to the number of CPU cores.
+        :type nprocs: int, optional
+
+        :returns: Two arrays: zenith angles and azimuth angles.
+        :rtype: tuple of numpy.ndarray
+        """
+        assert len(latitudes) == len(longitudes) == len(unix_times), "Input arrays must be the same length"
+
+        if nprocs is None:
+            nprocs = get_default_nprocs()
+
+        args_list = list(zip(latitudes, longitudes, unix_times))
+#       nprocs = nprocs or cpu_count()
+
+        self.log.debug(f'Using {nprocs} processes to compute solar angles.')
+        self.log.debug(f'Using {cpu_count()} processes to compute solar angles.')
+
+        with Pool(nprocs) as pool:
+            results = pool.starmap(compute_solar_angles, args_list)
+
+        self.log.debug(f'Using {nprocs} processes to compute solar angles --- done')
+        zenith_angles, azimuth_angles = zip(*results)
+        zenith_angles = np.array(zenith_angles)
+        azimuth_angles = np.array(azimuth_angles) 
+        return zenith_angles, azimuth_angles
+
+
+    def _add_solar_angles(self, container, category):
+
+        satId = container.get('satelliteId', category)
+        if not satId.size:
+            paths = container.get_paths('latitude', category)
+            dummy = container.get('latitude', category)
+            container.add('solarZenithAngle', dummy, paths, category)
+            container.add('solarAzimuthAngle', dummy, paths, category)
+            return
+
+        # Prepare input arrays 
+        unix_times = container.get('timestamp', category)
+        latitudes = container.get('latitude', category)
+        longitudes = container.get('longitude', category)
+        self.log.debug(f'latitudes min/max = {latitudes.min()} {latitudes.max()}')
+        self.log.debug(f'longitudes min/max = {longitudes.min()} {longitudes.max()}')
+        self.log.debug(f'unix_times min/max = {unix_times.min()} {unix_times.max()}')
+
+        zenith_angles, azimuth_angles = self._compute_solar_angles_parallel(latitudes, longitudes, unix_times)
+
+        self.log.debug(f'zenith_angles min/max = {zenith_angles.min()} {zenith_angles.max()}')
+        self.log.debug(f'azimuth_angles min/max = {azimuth_angles.min()} {azimuth_angles.max()}')
+
+        paths = container.get_paths('latitude', category)
+        self.log.debug(f'paths = {paths}')
+        container.add('solarZenithAngle', zenith_angles, paths, category)
+        container.add('solarAzimuthAngle', azimuth_angles, paths, category)
+
+add_main_functions(BufrSsmisObsBuilder)

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -2,77 +2,11 @@
 import os
 import numpy as np
 import numpy.ma as ma
-import pytz
-from pysolar.solar import get_altitude, get_azimuth
-from datetime import datetime, timezone
 from multiprocessing import Pool, cpu_count
 
 import bufr
-from bufr.obs_builder import ObsBuilder, add_main_functions
-
-
-def map_path(map_file_name):
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(script_dir, map_file_name)
-
-
-def get_default_nprocs(default=8):
-    """
-    Determine the number of processes to use.
-
-    The number of processes is determined from the environment variables
-    `CPUS_PER_TASK`, `SLURM_CPUS_PER_TASK`, or falls back to the default value.
-
-    Examples from command line:
-        1. Run with 1 slurm task and reserve 12 CPU cores for this one task.
-           In Python, this will spawn 12 worker processes via multiprocessing.Pool.
-           (SLURM_CPUS_PER_TASK = 12)
-           ``srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py``
-
-        2. Run without slurm and tell Python to spawn 12 worker processes.
-           ``export CPUS_PER_TASKS=12``
-           ``python bufr_ssmis.py``
-
-    :param default: Fallback default if nothing is found. Default is 8.
-    :type default: int
-
-    :return: Number of processes to use.
-    :rtype: int
-    """
-
-    env_nprocs = os.getenv("CPUS_PER_TASK")
-    slurm_nprocs = os.environ.get("SLURM_CPUS_PER_TASK")
-
-    print(f"CPUS_PER_TASK={env_nprocs}, SLURM_CPUS_PER_TASK={slurm_nprocs}")
-
-    try:
-        return int(env_nprocs or slurm_nprocs or default)
-    except ValueError:
-        print(f"[WARN] Invalid environment variable value. Falling back to default: {default}")
-        return default
-
-
-def compute_solar_angles(lat, lon, unix_time):
-    """
-    Compute solar zenith and azimuth angles for a single point.
-
-    :param lat: Latitude in degrees.
-    :type lat: float
-    :param lon: Longitude in degrees.
-    :type lon: float
-    :param unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
-    :type unix_time: int
-
-    :return: A tuple containing zenith angle and azimuth angle.
-    :rtype: tuple(float, float)
-    """
-
-    dt = datetime.fromtimestamp(int(unix_time), tz=timezone.utc)
-    altitude = get_altitude(lat, lon, dt)
-    azimuth = get_azimuth(lat, lon, dt)
-    zenith = 90.0 - altitude
-
-    return zenith, azimuth
+from bufr.obs_builder import ObsBuilder, add_main_functions, map_path, get_default_nprocs
+from bufr.transforms.geometry import compute_solar_angles
 
 
 MAPPING_PATH = map_path('bufr_ssmis.yaml')

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -101,6 +101,7 @@ class BufrSsmisObsBuilder(ObsBuilder):
     def __init__(self):
         """
         Initialize the BufrSsmisObsBuilder class.
+
         Inherits from ObsBuilder and sets up the mapping path and logger.
         """
 

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -18,29 +18,28 @@ def map_path(map_file_name):
 
 def get_default_nprocs(default=8):
     """
-    Determine number of processes to use from CPUS_PER_TASK, SLURM_CPUS_PER_TASK, or fallback.
+    Determine the number of processes to use.
 
-    SLURM_CPUS_PER_TASK - auto-detected from slurm
-    CPU_PER_TASK - input from user
+    The number of processes is determined from the environment variables
+    `CPUS_PER_TASK`, `SLURM_CPUS_PER_TASK`, or falls back to the default value.
 
     Examples from command line:
-    1. Run with 1 slurm task and reserve 12 CPU cores for this one task.
-       In Python, this will spawn 12 worker processes via multiprocessing.Pool.
-       (SLURM_CPUS_PER_TASK = 12)
+        1. Run with 1 slurm task and reserve 12 CPU cores for this one task.
+           In Python, this will spawn 12 worker processes via multiprocessing.Pool.
+           (SLURM_CPUS_PER_TASK = 12)
+           ``srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py``
 
-       srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py
+        2. Run without slurm and tell Python to spawn 12 worker processes.
+           ``export CPUS_PER_TASKS=12``
+           ``python bufr_ssmis.py``
 
-    2. Run without slurm and tell Python to spawn 12 worker processes via myltiprocessing.Pool.
+    :param default: Fallback default if nothing is found. Default is 8.
+    :type default: int
 
-       export CPUS_PER_TASKS=12
-       python bufr_ssmis.py
-
-    Parameters:
-        default: Fallback default if nothing is found.
-
-    Returns:
-        Number of processes to use.
+    :return: Number of processes to use.
+    :rtype: int
     """
+
     env_nprocs = os.getenv("CPUS_PER_TASK")
     slurm_nprocs = os.environ.get("SLURM_CPUS_PER_TASK")
 
@@ -57,12 +56,15 @@ def compute_solar_angles(lat, lon, unix_time):
     """
     Compute solar zenith and azimuth angles for a single point.
 
-    Parameters:
-        lat: Latitude in degrees.
-        lon: Longitude in degrees.
-        unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
-    Returns:
-        tuple: zenith angle, azimuth angle
+    :param lat: Latitude in degrees.
+    :type lat: float
+    :param lon: Longitude in degrees.
+    :type lon: float
+    :param unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
+    :type unix_time: int
+
+    :return: A tuple containing zenith angle and azimuth angle.
+    :rtype: tuple(float, float)
     """
 
     dt = datetime.fromtimestamp(int(unix_time), tz=timezone.utc)
@@ -77,10 +79,32 @@ MAPPING_PATH = map_path('bufr_ssmis.yaml')
 
 
 class BufrSsmisObsBuilder(ObsBuilder):
+    """
+    Class for building observations from SSMIS BUFR data.
+
+    This class extends `ObsBuilder` to include specific logic for processing
+    SSMIS data such as solar angles and satellite ascending/descending orbits.
+
+    :param mapping_path: Path to the mapping file.
+    :type mapping_path: str
+    """
+
     def __init__(self):
         super().__init__(MAPPING_PATH, log_name=os.path.basename(__file__))
 
     def make_obs(self, comm, input_path):
+        """
+        Generate observations from BUFR data.
+
+        :param comm: MPI communicator for parallel processing.
+        :type comm: MPI.Comm
+        :param input_path: Path to the input BUFR file.
+        :type input_path: str
+
+        :return: Container with generated observations.
+        :rtype: Container
+        """
+
         # Get container from mapping file first
         self.log.info('Get container from bufr')
         container = super().make_obs(comm, input_path)
@@ -140,9 +164,12 @@ class BufrSsmisObsBuilder(ObsBuilder):
 
     def _add_satellite_ascend_descent_orbit(self, container, category):
         """
-        Determine satellite orbit type (ascending or descending) based on latitude changes
-        if latitude increases, this is ascending orbit and the orbit type is set to 1
-        if latitude decreases, this is descending orbit and the orbit type is set to -1
+        Determine satellite orbit type (ascending or descending) based on latitude changes.
+
+        :param container: Observation data container.
+        :type container: Container
+        :param category: Data category to process.
+        :type category: str
         """
 
         satId = container.get('satelliteId', category)
@@ -176,13 +203,17 @@ class BufrSsmisObsBuilder(ObsBuilder):
         """
         Compute solar zenith and azimuth angles in parallel using multiprocessing.
 
-        Parameters:
-            latitudes: Array of latitudes in degrees.
-            longitudes: Array of longitudes in degrees.
-            unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
-            nprocs: Number of processes to use. Defaults to the number of CPU cores.
+        :param latitudes: Array of latitudes in degrees.
+        :type latitudes: numpy.ndarray
+        :param longitudes: Array of longitudes in degrees.
+        :type longitudes: numpy.ndarray
+        :param unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
+        :type unix_times: numpy.ndarray
+        :param nprocs: Number of processes to use. Defaults to the number of CPU cores.
+        :type nprocs: int, optional
 
-        Returns: Two arrays: zenith angles and azimuth angles.
+        :return: Two arrays: zenith angles and azimuth angles.
+        :rtype: tuple(numpy.ndarray, numpy.ndarray)
         """
 
         assert len(latitudes) == len(longitudes) == len(unix_times), "Input arrays must be the same length"
@@ -206,7 +237,12 @@ class BufrSsmisObsBuilder(ObsBuilder):
 
     def _add_solar_angles(self, container, category):
         """
-        Compute and add solar zenith and azimuth angles to container
+        Compute and add solar zenith and azimuth angles to the observation container.
+
+        :param container: Observation data container.
+        :type container: Container
+        :param category: Data category to process.
+        :type category: str
         """
 
         satId = container.get('satelliteId', category)

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -155,36 +155,13 @@ class BufrSsmisObsBuilder(ObsBuilder):
         """
 
         description = super()._make_description()
-        self._add_solar_angles_descriptions(description)
-        self._add_satellite_ascend_descend_orbit_descriptions(description)
+        self._add_new_variable_descriptions(description)
 
         return description
 
-    def _add_solar_angles_descriptions(self, description):
+    def _add_new_variable_descriptions(self, description):
         """
-        Add solar angle descriptions to the observation metadata.
-
-        :param description: Observation description container.
-        :type description: Description
-        """
-
-        description.add_variables([
-            {
-                'name': 'MetaData/solarZenithAngle',
-                'source': 'solarZenithAngle',
-                'units': 'degree',
-                'longName': 'Solar Zenith Angle',
-            },
-            {
-                'name': 'MetaData/solarAzimuthAngle',
-                'source': 'solarAzimuthAngle',
-                'units': 'degree',
-                'longName': 'Solar Azimuth Angle',
-            }])
-
-    def _add_satellite_ascend_descend_orbit_descriptions(self, description):
-        """
-        Add satellite orbit descriptions to the observation metadata.
+        Add solar angle and orbit flag descriptions to the observation metadata.
 
         :param description: Observation description container.
         :type description: Description
@@ -196,6 +173,18 @@ class BufrSsmisObsBuilder(ObsBuilder):
                 'source': 'satelliteAscendingFlag',
                 'units': '1',
                 'longName': 'Satellite Ascending/Descending Orbit Flag (Ascend:1; Descend:-1)',
+            },
+            {
+                'name': 'MetaData/solarZenithAngle',
+                'source': 'solarZenithAngle',
+                'units': 'degree',
+                'longName': 'Solar Zenith Angle',
+            },
+            {
+                'name': 'MetaData/solarAzimuthAngle',
+                'source': 'solarAzimuthAngle',
+                'units': 'degree',
+                'longName': 'Solar Azimuth Angle',
             }])
 
     def _add_satellite_ascend_descent_orbit(self, container, category):

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -86,8 +86,6 @@ class BufrSsmisObsBuilder(ObsBuilder):
         self.log.info('Get container from bufr')
         container = super().make_obs(comm, input_path)
     
-        self.log.debug(f'comm rank : {comm.rank()}')
-        self.log.debug(f'comm size : {comm.size()}')
         self.log.debug(f'container list (original): {container.list()}')
         self.log.debug(f'all_sub_categories =  {container.all_sub_categories()}')
         self.log.debug(f'category map =  {container.get_category_map()}')

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -12,42 +12,34 @@ from bufr.obs_builder import ObsBuilder, add_main_functions
 
 
 def map_path(map_file_name):
-    """
-    Generate the full path to the mapping file.
-
-    :param map_file_name: Name of the mapping file.
-    :type map_file_name: str
-    :return: Full path to the mapping file.
-    :rtype: str
-    """
     script_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(script_dir, map_file_name)
 
 
 def get_default_nprocs(default=8):
     """
-    Determine the number of processes to use from environment variables or fallback to a default.
+    Determine number of processes to use from CPUS_PER_TASK, SLURM_CPUS_PER_TASK, or fallback.
 
-    Environment Variables:
-        - `SLURM_CPUS_PER_TASK`: Auto-detected from Slurm.
-        - `CPUS_PER_TASK`: Input provided by the user.
+    SLURM_CPUS_PER_TASK - auto-detected from slurm
+    CPU_PER_TASK - input from user
 
-    Examples:
-        1. Run with 1 Slurm task and reserve 12 CPU cores for this one task.
-           This spawns 12 worker processes via `multiprocessing.Pool`.
-           (SLURM_CPUS_PER_TASK = 12)
-           Usage:
-               srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py
+    Examples from command line:
+    1. Run with 1 slurm task and reserve 12 CPU cores for this one task.
+       In Python, this will spawn 12 worker processes via multiprocessing.Pool.
+       (SLURM_CPUS_PER_TASK = 12)
 
-        2. Run without Slurm, specifying the number of worker processes.
-           Usage:
-               export CPUS_PER_TASK=12
-               python bufr_ssmis.py
+       srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py
 
-    :param default: Fallback default if environment variables are not set. Defaults to 8.
-    :type default: int
-    :return: Number of processes to use.
-    :rtype: int
+    2. Run without slurm and tell Python to spawn 12 worker processes via myltiprocessing.Pool.
+
+       export CPUS_PER_TASKS=12
+       python bufr_ssmis.py
+
+    Parameters:
+        default: Fallback default if nothing is found.
+
+    Returns:
+        Number of processes to use.
     """
     env_nprocs = os.getenv("CPUS_PER_TASK")
     slurm_nprocs = os.environ.get("SLURM_CPUS_PER_TASK")
@@ -63,17 +55,16 @@ def get_default_nprocs(default=8):
 
 def compute_solar_angles(lat, lon, unix_time):
     """
-    Compute solar zenith and azimuth angles for a geographical point.
+    Compute solar zenith and azimuth angles for a single point.
 
-    :param lat: Latitude in degrees.
-    :type lat: float
-    :param lon: Longitude in degrees.
-    :type lon: float
-    :param unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
-    :type unix_time: int
-    :return: Tuple containing zenith angle and azimuth angle (in degrees).
-    :rtype: tuple(float, float)
+    Parameters:
+        lat: Latitude in degrees.
+        lon: Longitude in degrees.
+        unix_time: Unix timestamp (seconds since 1970-01-01T00:00:00Z).
+    Returns:
+        tuple: zenith angle, azimuth angle
     """
+
     dt = datetime.fromtimestamp(int(unix_time), tz=timezone.utc)
     altitude = get_altitude(lat, lon, dt)
     azimuth = get_azimuth(lat, lon, dt)
@@ -86,39 +77,21 @@ MAPPING_PATH = map_path('bufr_ssmis.yaml')
 
 
 class BufrSsmisObsBuilder(ObsBuilder):
-    """
-    Builder class for processing BUFR SSMIS observations.
-
-    This class extends the `ObsBuilder` and provides methods to construct
-    observation data, add derived variables, and manage mapping configurations.
-    """
-
     def __init__(self):
-        """
-        Initialize the BufrSsmisObsBuilder with the mapping path and log name.
-        """
         super().__init__(MAPPING_PATH, log_name=os.path.basename(__file__))
 
     def make_obs(self, comm, input_path):
-        """
-        Create observations and add derived data to the observation container.
-
-        :param comm: Communication object for distributed processing.
-        :type comm: obj
-        :param input_path: Path to the input file.
-        :type input_path: str
-        :return: Updated observation container.
-        :rtype: obj
-        """
+        # Get container from mapping file first
         self.log.info('Get container from bufr')
         container = super().make_obs(comm, input_path)
 
         self.log.debug(f'container list (original): {container.list()}')
-        self.log.debug(f'all_sub_categories = {container.all_sub_categories()}')
-        self.log.debug(f'category map = {container.get_category_map()}')
+        self.log.debug(f'all_sub_categories =  {container.all_sub_categories()}')
+        self.log.debug(f'category map =  {container.get_category_map()}')
 
         # Add new/derived data into container
         for cat in container.all_sub_categories():
+
             self.log.debug(f'category = {cat}')
 
             satId = container.get('satelliteId', cat)
@@ -134,18 +107,44 @@ class BufrSsmisObsBuilder(ObsBuilder):
 
         return container
 
+    def _make_description(self):
+        description = super()._make_description()
+        self._add_solar_angles_descriptions(description)
+        self._add_satellite_ascend_descend_orbit_descriptions(description)
+
+        return description
+
+    def _add_solar_angles_descriptions(self, description):
+        description.add_variables([
+            {
+                'name': 'MetaData/solarZenithAngle',
+                'source': 'solarZenithAngle',
+                'units': 'degree',
+                'longName': 'Solar Zenith Angle',
+            },
+            {
+                'name': 'MetaData/solarAzimuthAngle',
+                'source': 'solarAzimuthAngle',
+                'units': 'degree',
+                'longName': 'Solar Azimuth Angle',
+            }])
+
+    def _add_satellite_ascend_descend_orbit_descriptions(self, description):
+        description.add_variables([
+            {
+                'name': 'MetaData/satelliteAscendingFlag',
+                'source': 'satelliteAscendingFlag',
+                'units': '1',
+                'longName': 'Satellite Ascending/Descending Orbit Flag (Ascend:1; Descend:-1)',
+            }])
+
     def _add_satellite_ascend_descent_orbit(self, container, category):
         """
-        Determine satellite orbit type (ascending or descending) based on latitude changes.
-
-        If the latitude increases, the orbit is ascending (flag = 1).
-        If the latitude decreases, the orbit is descending (flag = -1).
-
-        :param container: Observation data container.
-        :type container: obj
-        :param category: Observation category.
-        :type category: obj
+        Determine satellite orbit type (ascending or descending) based on latitude changes
+        if latitude increases, this is ascending orbit and the orbit type is set to 1
+        if latitude decreases, this is descending orbit and the orbit type is set to -1
         """
+
         satId = container.get('satelliteId', category)
 
         if not satId.size:
@@ -155,31 +154,37 @@ class BufrSsmisObsBuilder(ObsBuilder):
             return
 
         # Get data from container
+        # ephemeris data - latitude values in order of time
         first_lat = container.get('latitude1', category)
+        self.log.debug(f'first_lat min/max = {first_lat.min()} {first_lat.max()}')
         second_lat = container.get('latitude2', category)
+        self.log.debug(f'second_lat min/max = {second_lat.min()} {second_lat.max()}')
         fovn = container.get('fieldOfViewNumber', category)
+        self.log.debug(f'fovn min/max = {fovn.min()} {fovn.max()}')
 
         # Determine ascending/descending mode
+        # Compare latitude between the first and second records
         orbit = np.where(second_lat > first_lat, 1, -1).astype(np.int32)
 
+        self.log.debug(f'orbit min/max = {orbit.min()} {orbit.max()}')
+
         paths = container.get_paths('fieldOfViewNumber', category)
+        self.log.debug(f'paths = {paths}')
         container.add('satelliteAscendingFlag', orbit, paths, category)
 
     def _compute_solar_angles_parallel(self, latitudes, longitudes, unix_times, nprocs=None):
         """
         Compute solar zenith and azimuth angles in parallel using multiprocessing.
 
-        :param latitudes: Array of latitudes in degrees.
-        :type latitudes: numpy.ndarray
-        :param longitudes: Array of longitudes in degrees.
-        :type longitudes: numpy.ndarray
-        :param unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
-        :type unix_times: numpy.ndarray
-        :param nprocs: Number of processes to use. If None, defaults to the number of CPU cores.
-        :type nprocs: int, optional
-        :return: Two arrays containing zenith angles and azimuth angles, respectively.
-        :rtype: tuple(numpy.ndarray, numpy.ndarray)
+        Parameters:
+            latitudes: Array of latitudes in degrees.
+            longitudes: Array of longitudes in degrees.
+            unix_times: Array of Unix timestamps (seconds since 1970-01-01T00:00:00Z).
+            nprocs: Number of processes to use. Defaults to the number of CPU cores.
+
+        Returns: Two arrays: zenith angles and azimuth angles.
         """
+
         assert len(latitudes) == len(longitudes) == len(unix_times), "Input arrays must be the same length"
 
         if nprocs is None:
@@ -187,11 +192,50 @@ class BufrSsmisObsBuilder(ObsBuilder):
 
         args_list = list(zip(latitudes, longitudes, unix_times))
 
+        self.log.debug(f'Using {nprocs} processes to compute solar angles.')
+
         with Pool(nprocs) as pool:
             results = pool.starmap(compute_solar_angles, args_list)
 
+        self.log.debug(f'Using {nprocs} processes to compute solar angles --- done')
         zenith_angles, azimuth_angles = zip(*results)
-        return np.array(zenith_angles), np.array(azimuth_angles)
+        zenith_angles = np.array(zenith_angles)
+        azimuth_angles = np.array(azimuth_angles)
+
+        return zenith_angles, azimuth_angles
+
+    def _add_solar_angles(self, container, category):
+        """
+        Compute and add solar zenith and azimuth angles to container
+        """
+
+        satId = container.get('satelliteId', category)
+        if not satId.size:
+            paths = container.get_paths('latitude', category)
+            dummy = container.get('latitude', category)
+            container.add('solarZenithAngle', dummy, paths, category)
+            container.add('solarAzimuthAngle', dummy, paths, category)
+            return
+
+        # Prepare input arrays
+        unix_times = container.get('timestamp', category)
+        latitudes = container.get('latitude', category)
+        longitudes = container.get('longitude', category)
+        self.log.debug(f'latitudes min/max = {latitudes.min()} {latitudes.max()}')
+        self.log.debug(f'longitudes min/max = {longitudes.min()} {longitudes.max()}')
+        self.log.debug(f'unix_times min/max = {unix_times.min()} {unix_times.max()}')
+
+        # Calculate solar angles
+        zenith_angles, azimuth_angles = self._compute_solar_angles_parallel(latitudes, longitudes, unix_times)
+
+        self.log.debug(f'zenith_angles min/max = {zenith_angles.min()} {zenith_angles.max()}')
+        self.log.debug(f'azimuth_angles min/max = {azimuth_angles.min()} {azimuth_angles.max()}')
+
+        # Add solar angles to contained
+        paths = container.get_paths('latitude', category)
+        self.log.debug(f'paths = {paths}')
+        container.add('solarZenithAngle', zenith_angles, paths, category)
+        container.add('solarAzimuthAngle', azimuth_angles, paths, category)
 
 
 add_main_functions(BufrSsmisObsBuilder)

--- a/dump/mapping/bufr_ssmis.py
+++ b/dump/mapping/bufr_ssmis.py
@@ -121,13 +121,13 @@ class BufrSsmisObsBuilder(ObsBuilder):
                 'name': 'MetaData/solarZenithAngle',
                 'source': 'solarZenithAngle',
                 'units': 'degree',
-                'longName': 'Solar Zenith Angle)',
+                'longName': 'Solar Zenith Angle',
             },
             {
                 'name': 'MetaData/solarAzimuthAngle',
                 'source': 'solarAzimuthAngle',
                 'units': 'degree',
-                'longName': 'Solar Azimuth Angle)',
+                'longName': 'Solar Azimuth Angle',
             }])
 
 

--- a/dump/mapping/bufr_ssmis.yaml
+++ b/dump/mapping/bufr_ssmis.yaml
@@ -1,0 +1,200 @@
+bufr:
+  variables:
+    # MetaData
+    timestamp:
+      datetime:
+        year: "*/YEAR"
+        month: "*/MNTH"
+        day: "*/DAYS"
+        hour: "*/HOUR"
+        minute: "*/MINU"
+        second: "*/SECO"
+
+    latitude:
+      query: "*/CLAT"
+
+    latitude1:
+      query: "*/SATEPHEM{1}/CLATH"
+
+    latitude2:
+      query: "*/SATEPHEM{2}/CLATH"
+
+    longitude:
+      query: "*/CLON"
+
+    satelliteId:
+      query: "*/SAID"
+
+    scanLineNumber:
+      query: "*/SLNM"
+
+    fieldOfViewNumber:
+      query: "*/FOVN"
+
+    surfaceFlag:
+      query: "*/SFLG"
+
+    rainFlag:
+      query: "*/RFLAG"
+
+    sensorChannelNumber:
+      query: "*/SSMISCHN/CHNM"
+
+#    brightnessTemperature:
+#      query: "*/SSMISCHN/TMBR"
+
+    sensorScanAngle:
+      sensorScanAngle:
+        fieldOfViewNumber: "*/FOVN"
+        scanStart: 0.0 
+        scanStep: 0.0 
+        sensor: ssmis
+
+    remappedBT:
+      remappedBrightnessTemperature:
+        sensor: ssmis
+        method: 1
+        satelliteId: "*/SAID"
+        latitude: "*/CLAT"
+        longitude: "*/CLON"
+        fieldOfViewNumber: "*/FOVN"
+        rainFlag: "*/RFLAG"
+        sensorChannelNumber: "*/SSMISCHN/CHNM"
+        brightnessTemperature: "*/SSMISCHN/TMBR"
+        obsTime:
+          year: "*/YEAR"
+          month: "*/MNTH"
+          day: "*/DAYS"
+          hour: "*/HOUR"
+          minute: "*/MINU"
+          second: "*/SECO"
+
+  splits:
+    satId:
+      category:
+        variable: satelliteId
+        map:
+          _249: f16
+          _285: f17
+          _286: f18
+
+encoder:
+  dimensions:
+    - name: Channel
+      source: variables/sensorChannelNumber  
+      path: "*/SSMISCHN"
+  
+  globals:
+    - name: "platformCommonName"
+      type: string
+      value: "SSMIS-DMSP18"
+  
+    - name: "platformLongDescription"
+      type: string
+      value: "MTYP 021-201 DMSP SSM/IS Tb (UNIFIED PRE-PROCESSOR)"
+  
+  globals:
+    - name: "platformCommonName"
+      type: string
+      value: "JPSS"
+
+    - name: "platformLongDescription"
+      type: string
+      value: "Joint Polar Satellite System"
+
+    - name: "sensor"
+      type: string
+      value: "Special Sensor Microwave Imager / Sounder (SSMIS)"
+
+    - name: "source"
+      type: string
+      value: "NCEP BUFR Dump for SSMIS brightness temperature data (ssmisu)"
+
+    - name: "providerFullName"
+      type: string
+      value: "National Environmental Satellite, Data, and Information Service"
+
+    - name: "processingLevel"
+      type: string
+      value: "Level-1B"
+
+    - name: "converter"
+      type: string
+      value: "BUFR"
+
+  variables:
+    # MetaData
+    - name: "MetaData/dateTime"
+      source: variables/timestamp
+      longName: "Datetime"
+      units: "seconds since 1970-01-01T00:00:00Z" 
+  
+    - name: "MetaData/latitude"
+      source: variables/latitude
+      longName: "Latitude"
+      units: "degree_north"
+      range: [-90, 90]
+  
+#    - name: "MetaData/latitudeSatEphem1"
+#      source: variables/latitude1
+#      longName: "Latitude from SATEPHEM Record 1 (high resolution)"
+#      units: "degree_north"
+#      range: [-90, 90]
+  
+#    - name: "MetaData/latitudeSatEphem2"
+#      source: variables/latitude2
+#      longName: "Latitude from SATEPHEM Record 2 (high resolution)"
+#      units: "degree_north"
+#      range: [-90, 90]
+  
+    - name: "MetaData/longitude"
+      source: variables/longitude
+      longName: "Longitude"
+      units: "degree_east"
+  
+    - name: "MetaData/satelliteIdentifier"
+      source: variables/satelliteId
+      longName: "Satellite Identifier"
+  
+    - name: "MetaData/sensorScanPosition"
+      source: variables/fieldOfViewNumber
+      longName: "Field of View Number"
+  
+    - name: "MetaData/sensorChannelNumber"
+      source: variables/sensorChannelNumber
+      longName: "Sensor Channel Number"
+  
+    - name: "MetaData/sensorViewAngle"
+      source: variables/sensorScanAngle
+      longName: "Sensor View Angle"
+      units: "degree"
+  
+    - name: "MetaData/earthSurfaceType"
+      source: variables/surfaceFlag
+      longName: "Earth Surface Type"
+  
+    - name: "MetaData/rainFlag"
+      source: variables/rainFlag
+      longName: "Rain Flag (1:rain; 0:no rain (clear); -1:no determined"
+  
+    - name: "MetaData/scanLineNumber"
+      source: variables/scanLineNumber
+      longName: "Scan Line Number"
+  
+#    # ObsValue
+#    # Brightness Temperature
+#    - name: "ObsValue/brightnessTemperature"
+#      source: variables/brightnessTemperature
+#      longName: "Brightness Temperature"
+#      units: "K"
+#      range: [120, 500]
+#      chunks: [10000, 24]
+
+    # ObsValue
+    # Remapped Brightness Temperature
+    - name: "ObsValue/brightnessTemperature"
+      source: variables/remappedBT
+      longName: "3-by-3 Averaged Brightness Temperature"
+      units: "K"
+      range: [120, 500]
+      chunks: [10000, 24]


### PR DESCRIPTION
This PR adds two files for SSMIS
- mapping YAML
- Python script   --- pass Python coding norm test

Notes:
- This PR should be tested with [bufr-query PR #74](https://github.com/NOAA-EMC/bufr-query/pull/74)

SSMIS data processing has the following features:
- spatial averaging (this is implemented in bufr-query variable transform) and it can be used by activated the feature from YAML
- Add new variables via the obs builder Python API
    - satellite ascending/descending orbit flag (1 for ascending and -1 for descending)
    - solar zenith and azimuth angles (use pysolar)

Notes:
- Documentation is in Sphnix style (following discussion in Issue #35 )
- SSMIS data conversion includes spatial averaging.  Therefore the processing can only run with one MPI task.  
- The solar angles calculation is done using pysolar.  The functions used do not support vectors.  Therefore, the calculation of solar angles are implemented with multiprocessing (e.g., one MPI task and spawned with 12 CPUs)

   ```
             srun -n 1 --cpus_per_tasks=12 python bufr_ssmis.py
   ```
   or 
   ```
             export CPUS_PER_TASKS=12
             python bufr_ssmis.py``
   ```
   
Test: script2netcdf validated
Plots for output netCDF from SSMIS converter   
 
![gdas_solarZenithAngle_ssmis_f17_channel_4](https://github.com/user-attachments/assets/8a90a7c6-9f69-435a-8d15-46b3aa6e698d)

![gdas_satelliteAscendingFlag_ssmis_f17_channel_4](https://github.com/user-attachments/assets/c583697f-7ce7-435c-969b-1ef953fcd090)

![gdas_ObsValue_ssmis_f17_channel_4](https://github.com/user-attachments/assets/74e80396-4865-4ffa-a18f-3bf822ff98d9)


