### PR TITLE
Add ASCAT (satellite-derived winds) mapping file and Python script

### DIFF
--- a/dump/mapping/bufr_satwnd_ascat.py
+++ b/dump/mapping/bufr_satwnd_ascat.py
@@ -4,8 +4,8 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import ObsBuilder, add_main_functions
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder, map_path
+from bufr.obs_builder import ObsBuilder, add_main_functions, map_path
+from bufr.transforms.wind import compute_wind_components 
 
 
 MAPPING_PATH = map_path('bufr_satwnd_ascat.yaml')
@@ -13,33 +13,17 @@ MAPPING_PATH = map_path('bufr_satwnd_ascat.yaml')
 
 class BufrAscatObsBuilder(ObsBuilder):
     """
-    A class to build satellite wind observations for ASCAT data.
+    A builder class to generate satellite wind observations from ASCAT BUFR input.
 
-    Attributes:
-        _wind_helper (SatWndAmvObsBuilder): Helper class for computing wind components.
+    Inherits from :class:`bufr.obs_builder.ObsBuilder` and uses a mapping file to 
+    extract wind speed and direction, compute wind vector components, and attach 
+    observation metadata.
     """
 
     def __init__(self):
-        """
-        Initializes the BufrAscatObsBuilder.
-
-        Inherits from ObsBuilder and sets up the mapping path and logger.
-        """
-
         super().__init__(MAPPING_PATH, log_name=os.path.basename(__file__))
-        self._wind_helper = SatWndAmvObsBuilder(MAPPING_PATH)
 
     def make_obs(self, comm, input_path):
-        """
-        Generates observation data for a given input file.
-
-        Args:
-            comm: Communication handler for parallel processing.
-            input_path (str): Path to the input file.
-
-        Returns:
-            container: The processed observation container.
-        """
 
         # Get container from mapping file first
         self.log.info('Get container from bufr')
@@ -74,7 +58,7 @@ class BufrAscatObsBuilder(ObsBuilder):
             self.log.debug(f'wdir min/max = {wdir.min()} {wdir.max()}')
             self.log.debug(f'wspd min/max = {wspd.min()} {wspd.max()}')
 
-            uob, vob = self._wind_helper._compute_wind_components(wdir, wspd)
+            uob, vob = compute_wind_components(wspd, wdir)
             self.log.debug(f'uob min/max = {uob.min()} {uob.max()}')
             self.log.debug(f'vob min/max = {vob.min()} {vob.max()}')
 
@@ -95,14 +79,15 @@ class BufrAscatObsBuilder(ObsBuilder):
 
     def _get_obs_type(self, container, category):
         """
-        Retrieves the observation type for wind components.
+        Retrieve observation type values for wind components.
 
-        Args:
-            container: The observation container.
-            category: The observation category.
+        :param container: Observation container from BUFR input.
+        :type container: bufr.DataContainer
+        :param category: Subcategory identifier (e.g., sensor/platform group).
+        :type category: tuple
 
-        Returns:
-            np.ndarray: Array containing observation types for the category.
+        :returns: Array filled with observation type (290) for the given category.
+        :rtype: numpy.ndarray
         """
 
         satId = container.get('satelliteId', category)
@@ -119,26 +104,12 @@ class BufrAscatObsBuilder(ObsBuilder):
         return obstype
 
     def _make_description(self):
-        """
-        Constructs metadata descriptions for observations.
-
-        Returns:
-            description: Metadata descriptions for the observation variables.
-        """
-
         description = super()._make_description()
         self._add_new_variable_descriptions(description)
 
         return description
 
     def _add_new_variable_descriptions(self, description):
-        """
-        Adds metadata descriptions for new variables to the container.
-
-        Args:
-            description: Metadata container for descriptions.
-        """
-
         description.add_variables([
             {
                 'name': 'ObsValue/windEastward',
@@ -152,7 +123,7 @@ class BufrAscatObsBuilder(ObsBuilder):
                 'units': 'm s-1',
                 'longName': '10-meter V-Wind Component',
             },
-            {
+                        {
                 'name': 'ObsType/windEastward',
                 'source': 'obstype_windEastward',
                 'units': '1',

--- a/dump/mapping/bufr_satwnd_ascat.py
+++ b/dump/mapping/bufr_satwnd_ascat.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions, map_path
-from bufr.transforms.wind import compute_wind_components 
+from bufr.transforms.wind import compute_wind_components
 
 
 MAPPING_PATH = map_path('bufr_satwnd_ascat.yaml')
@@ -15,8 +15,8 @@ class BufrAscatObsBuilder(ObsBuilder):
     """
     A builder class to generate satellite wind observations from ASCAT BUFR input.
 
-    Inherits from :class:`bufr.obs_builder.ObsBuilder` and uses a mapping file to 
-    extract wind speed and direction, compute wind vector components, and attach 
+    Inherits from :class:`bufr.obs_builder.ObsBuilder` and uses a mapping file to
+    extract wind speed and direction, compute wind vector components, and attach
     observation metadata.
     """
 
@@ -123,7 +123,7 @@ class BufrAscatObsBuilder(ObsBuilder):
                 'units': 'm s-1',
                 'longName': '10-meter V-Wind Component',
             },
-                        {
+            {
                 'name': 'ObsType/windEastward',
                 'source': 'obstype_windEastward',
                 'units': '1',

--- a/dump/mapping/bufr_satwnd_ascat.py
+++ b/dump/mapping/bufr_satwnd_ascat.py
@@ -33,7 +33,7 @@ class BufrAscatObsBuilder(ObsBuilder):
             satId = container.get('satelliteId', cat)
             if not np.any(satId):
                 self.log.warning(f'category {cat[0]} does not exist in input file')
-    
+
                 paths = container.get_paths('windSpeedAt10M', cat)
                 dummy = container.get('windSpeedAt10M', cat)
                 container.add('windEastward', dummy, paths, cat)
@@ -43,7 +43,7 @@ class BufrAscatObsBuilder(ObsBuilder):
                 dummy = container.get('satelliteId', cat)
                 container.add('obstype_windEastward', dummy, paths, cat)
                 container.add('obstype_windNorthward', dummy, paths, cat)
-                continue 
+                continue
 
             wdir = container.get('windDirectionAt10M', cat)
             wspd = container.get('windSpeedAt10M', cat)
@@ -78,11 +78,10 @@ class BufrAscatObsBuilder(ObsBuilder):
             container.add('obstype_windEastward', dummy, paths, cat)
             container.add('obstype_windNorthward', dummy, paths, cat)
             return
-     
-        obstype = np.full_like(satId, 290) 
+
+        obstype = np.full_like(satId, 290)
 
         return obstype
-
 
     def _make_description(self):
         description = super()._make_description()
@@ -90,7 +89,6 @@ class BufrAscatObsBuilder(ObsBuilder):
         self._add_obs_type_descriptions(description)
 
         return description
-
 
     def _add_wind_components_descriptions(self, description):
         description.add_variables([
@@ -106,7 +104,6 @@ class BufrAscatObsBuilder(ObsBuilder):
                 'units': 'm s-1',
                 'longName': '10-meter V-Wind Component',
             }])
-
 
     def _add_obs_type_descriptions(self, description):
         description.add_variables([

--- a/dump/mapping/bufr_satwnd_ascat.py
+++ b/dump/mapping/bufr_satwnd_ascat.py
@@ -33,7 +33,7 @@ class BufrAscatObsBuilder(ObsBuilder):
             satId = container.get('satelliteId', cat)
             if not np.any(satId):
                 self.log.warning(f'category {cat[0]} does not exist in input file')
-
+    
                 paths = container.get_paths('windSpeedAt10M', cat)
                 dummy = container.get('windSpeedAt10M', cat)
                 container.add('windEastward', dummy, paths, cat)
@@ -43,7 +43,7 @@ class BufrAscatObsBuilder(ObsBuilder):
                 dummy = container.get('satelliteId', cat)
                 container.add('obstype_windEastward', dummy, paths, cat)
                 container.add('obstype_windNorthward', dummy, paths, cat)
-                continue
+                continue 
 
             wdir = container.get('windDirectionAt10M', cat)
             wspd = container.get('windSpeedAt10M', cat)
@@ -58,7 +58,7 @@ class BufrAscatObsBuilder(ObsBuilder):
             container.add('windEastward', uob, paths, cat)
             container.add('windNorthward', vob, paths, cat)
 
-            obstype = self._make_obs_type(container, cat)
+            obstype = self._get_obs_type(container, cat)
             paths = container.get_paths('satelliteId', cat)
             container.add('obstype_windEastward', obstype, paths, cat)
             container.add('obstype_windNorthward', obstype, paths, cat)
@@ -69,7 +69,7 @@ class BufrAscatObsBuilder(ObsBuilder):
 
         return container
 
-    def _make_obs_type(self, container, category):
+    def _get_obs_type(self, container, category):
         satId = container.get('satelliteId', category)
 
         if not satId.size:
@@ -78,10 +78,11 @@ class BufrAscatObsBuilder(ObsBuilder):
             container.add('obstype_windEastward', dummy, paths, cat)
             container.add('obstype_windNorthward', dummy, paths, cat)
             return
-
-        obstype = np.full_like(satId, 290)
+     
+        obstype = np.full_like(satId, 290) 
 
         return obstype
+
 
     def _make_description(self):
         description = super()._make_description()
@@ -89,6 +90,7 @@ class BufrAscatObsBuilder(ObsBuilder):
         self._add_obs_type_descriptions(description)
 
         return description
+
 
     def _add_wind_components_descriptions(self, description):
         description.add_variables([
@@ -104,6 +106,7 @@ class BufrAscatObsBuilder(ObsBuilder):
                 'units': 'm s-1',
                 'longName': '10-meter V-Wind Component',
             }])
+
 
     def _add_obs_type_descriptions(self, description):
         description.add_variables([

--- a/dump/mapping/bufr_satwnd_ascat.py
+++ b/dump/mapping/bufr_satwnd_ascat.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import os
+import numpy as np
+
+import bufr
+from bufr.obs_builder import ObsBuilder, add_main_functions
+from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder, map_path
+
+
+MAPPING_PATH = map_path('bufr_satwnd_ascat.yaml')
+
+
+class BufrAscatObsBuilder(ObsBuilder):
+    def __init__(self):
+        super().__init__(MAPPING_PATH, log_name=os.path.basename(__file__))
+        self._wind_helper = SatWndAmvObsBuilder(MAPPING_PATH)
+
+    def make_obs(self, comm, input_path):
+        # Get container from mapping file first
+        self.log.info('Get container from bufr')
+        container = super().make_obs(comm, input_path)
+
+        self.log.debug(f'container list (original): {container.list()}')
+        self.log.debug(f'all_sub_categories =  {container.all_sub_categories()}')
+        self.log.debug(f'category map =  {container.get_category_map()}')
+
+        # Add new/derived data into container
+        for cat in container.all_sub_categories():
+
+            self.log.debug(f'category = {cat}')
+
+            satId = container.get('satelliteId', cat)
+            if not np.any(satId):
+                self.log.warning(f'category {cat[0]} does not exist in input file')
+    
+                paths = container.get_paths('windSpeedAt10M', cat)
+                dummy = container.get('windSpeedAt10M', cat)
+                container.add('windEastward', dummy, paths, cat)
+                container.add('windNorthward', dummy, paths, cat)
+
+                paths = container.get_paths('satelliteId', cat)
+                dummy = container.get('satelliteId', cat)
+                container.add('obstype_windEastward', dummy, paths, cat)
+                container.add('obstype_windNorthward', dummy, paths, cat)
+                continue 
+
+            wdir = container.get('windDirectionAt10M', cat)
+            wspd = container.get('windSpeedAt10M', cat)
+            self.log.debug(f'wdir min/max = {wdir.min()} {wdir.max()}')
+            self.log.debug(f'wspd min/max = {wspd.min()} {wspd.max()}')
+
+            uob, vob = self._wind_helper._compute_wind_components(wdir, wspd)
+            self.log.debug(f'uob min/max = {uob.min()} {uob.max()}')
+            self.log.debug(f'vob min/max = {vob.min()} {vob.max()}')
+
+            paths = container.get_paths('windSpeedAt10M', cat)
+            container.add('windEastward', uob, paths, cat)
+            container.add('windNorthward', vob, paths, cat)
+
+            obstype = self._make_obs_type(container, cat)
+            paths = container.get_paths('satelliteId', cat)
+            container.add('obstype_windEastward', obstype, paths, cat)
+            container.add('obstype_windNorthward', obstype, paths, cat)
+
+        # Check
+        self.log.debug(f'container list (updated): {container.list()}')
+        self.log.debug(f'all_sub_categories {container.all_sub_categories()}')
+
+        return container
+
+    def _make_obs_type(self, container, category):
+        satId = container.get('satelliteId', category)
+
+        if not satId.size:
+            paths = container.get_paths('satelliteId', cat)
+            dummy = container.get('satelliteId', cat)
+            container.add('obstype_windEastward', dummy, paths, cat)
+            container.add('obstype_windNorthward', dummy, paths, cat)
+            return
+     
+        obstype = np.full_like(satId, 290) 
+
+        return obstype
+
+
+    def _make_description(self):
+        description = super()._make_description()
+        self._add_wind_components_descriptions(description)
+        self._add_obs_type_descriptions(description)
+
+        return description
+
+
+    def _add_wind_components_descriptions(self, description):
+        description.add_variables([
+            {
+                'name': 'ObsValue/windEastward',
+                'source': 'windEastward',
+                'units': 'm s-1',
+                'longName': '10-meter U-Wind Component',
+            },
+            {
+                'name': 'ObsValue/windNorthward',
+                'source': 'windNorthward',
+                'units': 'm s-1',
+                'longName': '10-meter V-Wind Component',
+            }])
+
+
+    def _add_obs_type_descriptions(self, description):
+        description.add_variables([
+            {
+                'name': 'ObsType/windEastward',
+                'source': 'obstype_windEastward',
+                'units': '1',
+                'longName': 'Observation Type for Wind Components',
+            },
+            {
+                'name': 'ObsType/windNorthward',
+                'source': 'obstype_windNorthward',
+                'units': '1',
+                'longName': 'Observation Type for Wind Components',
+            }])
+
+
+# Add main functions create_obs_file and create_obs_group
+add_main_functions(BufrAscatObsBuilder)

--- a/dump/mapping/bufr_satwnd_ascat.py
+++ b/dump/mapping/bufr_satwnd_ascat.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions, map_path
-from bufr.transforms.wind import compute_wind_components
+from bufr.transforms import compute_wind_components
 
 
 MAPPING_PATH = map_path('bufr_satwnd_ascat.yaml')

--- a/dump/mapping/bufr_satwnd_ascat.py
+++ b/dump/mapping/bufr_satwnd_ascat.py
@@ -177,5 +177,5 @@ class BufrAscatObsBuilder(ObsBuilder):
             }])
 
 
-# Add main functions create_obs_file and create_obs_group
+# Add main functions create_obs_file or create_obs_group
 add_main_functions(BufrAscatObsBuilder)

--- a/dump/mapping/bufr_satwnd_ascat.py
+++ b/dump/mapping/bufr_satwnd_ascat.py
@@ -127,14 +127,13 @@ class BufrAscatObsBuilder(ObsBuilder):
         """
 
         description = super()._make_description()
-        self._add_wind_components_descriptions(description)
-        self._add_obs_type_descriptions(description)
+        self._add_new_variable_descriptions(description)
 
         return description
 
-    def _add_wind_components_descriptions(self, description):
+    def _add_new_variable_descriptions(self, description):
         """
-        Adds metadata descriptions for wind components to the container.
+        Adds metadata descriptions for new variables to the container.
 
         Args:
             description: Metadata container for descriptions.
@@ -152,17 +151,7 @@ class BufrAscatObsBuilder(ObsBuilder):
                 'source': 'windNorthward',
                 'units': 'm s-1',
                 'longName': '10-meter V-Wind Component',
-            }])
-
-    def _add_obs_type_descriptions(self, description):
-        """
-        Adds metadata descriptions for observation types to the container.
-
-        Args:
-            description: Metadata container for descriptions.
-        """
-
-        description.add_variables([
+            },
             {
                 'name': 'ObsType/windEastward',
                 'source': 'obstype_windEastward',

--- a/dump/mapping/bufr_satwnd_ascat.py
+++ b/dump/mapping/bufr_satwnd_ascat.py
@@ -12,11 +12,35 @@ MAPPING_PATH = map_path('bufr_satwnd_ascat.yaml')
 
 
 class BufrAscatObsBuilder(ObsBuilder):
+    """
+    A class to build satellite wind observations for ASCAT data.
+
+    Attributes:
+        _wind_helper (SatWndAmvObsBuilder): Helper class for computing wind components.
+    """
+
     def __init__(self):
+        """
+        Initializes the BufrAscatObsBuilder.
+
+        Inherits from ObsBuilder and sets up the mapping path and logger.
+        """
+
         super().__init__(MAPPING_PATH, log_name=os.path.basename(__file__))
         self._wind_helper = SatWndAmvObsBuilder(MAPPING_PATH)
 
     def make_obs(self, comm, input_path):
+        """
+        Generates observation data for a given input file.
+
+        Args:
+            comm: Communication handler for parallel processing.
+            input_path (str): Path to the input file.
+
+        Returns:
+            container: The processed observation container.
+        """
+
         # Get container from mapping file first
         self.log.info('Get container from bufr')
         container = super().make_obs(comm, input_path)
@@ -70,6 +94,17 @@ class BufrAscatObsBuilder(ObsBuilder):
         return container
 
     def _get_obs_type(self, container, category):
+        """
+        Retrieves the observation type for wind components.
+
+        Args:
+            container: The observation container.
+            category: The observation category.
+
+        Returns:
+            np.ndarray: Array containing observation types for the category.
+        """
+
         satId = container.get('satelliteId', category)
 
         if not satId.size:
@@ -84,6 +119,13 @@ class BufrAscatObsBuilder(ObsBuilder):
         return obstype
 
     def _make_description(self):
+        """
+        Constructs metadata descriptions for observations.
+
+        Returns:
+            description: Metadata descriptions for the observation variables.
+        """
+
         description = super()._make_description()
         self._add_wind_components_descriptions(description)
         self._add_obs_type_descriptions(description)
@@ -91,6 +133,13 @@ class BufrAscatObsBuilder(ObsBuilder):
         return description
 
     def _add_wind_components_descriptions(self, description):
+        """
+        Adds metadata descriptions for wind components to the container.
+
+        Args:
+            description: Metadata container for descriptions.
+        """
+
         description.add_variables([
             {
                 'name': 'ObsValue/windEastward',
@@ -106,6 +155,13 @@ class BufrAscatObsBuilder(ObsBuilder):
             }])
 
     def _add_obs_type_descriptions(self, description):
+        """
+        Adds metadata descriptions for observation types to the container.
+
+        Args:
+            description: Metadata container for descriptions.
+        """
+
         description.add_variables([
             {
                 'name': 'ObsType/windEastward',

--- a/dump/mapping/bufr_satwnd_ascat.yaml
+++ b/dump/mapping/bufr_satwnd_ascat.yaml
@@ -1,0 +1,128 @@
+bufr:
+  subsets:
+    - NC012122
+
+  variables:
+    # MetaData
+    timestamp:
+      datetime:
+        year: "*/YEAR"
+        month: "*/MNTH"
+        day: "*/DAYS"
+        hour: "*/HOUR"
+        minute: "*/MINU"
+        second: "*/SECO"
+
+    dataReceiptTime:
+      datetime:
+        year: "*/RCYR"
+        month: "*/RCMO"
+        day: "*/RCDY"
+        hour: "*/RCHR"
+        minute: "*/RCMI"
+
+    latitude:
+      query: "*/CLAT"
+
+    longitude:
+      query: "*/CLON"
+
+    satelliteId:
+      query: "*/SAID"
+
+    qualityFlags:
+      query: "*/WVCQ"
+
+    # ObsValue - Wind Direction
+    windDirectionAt10M:
+      query: '*/WD10'
+
+    # ObsValue - Wind Speed
+    windSpeedAt10M:
+      query: '*/WS10'
+
+  splits:
+    satId:
+      category:
+        variable: satelliteId
+        map:
+          _3: metop-b 
+          _4: metop-a 
+          _5: metop-c 
+
+encoder:
+# type: netcdf
+
+# dimensions:
+
+  globals:
+    - name: "platformCommonName"
+      type: string
+      value: "MetOp"
+
+    - name: "platformLongDescription"
+      type: string
+      value: "Meteorological Operational Satellite"
+
+    - name: "sensor"
+      type: string
+      value: "Advanced Scatterometer - ASCATW"
+
+    - name: "source"
+      type: string
+      value: "NCEP BUFR Dump for satellite derived surface wind components from ASCAT (scatw)"
+
+    - name: "providerFullName"
+      type: string
+      value: "National Environmental Satellite, Data, and Information Service"
+
+    - name: "processingLevel"
+      type: string
+      value: "Level-2"
+
+    - name: "converter"
+      type: string
+      value: "BUFR"
+
+  variables:
+    # MetaData 
+    - name: "MetaData/dateTime"
+      source: variables/timestamp
+      longName: "Observation Time"
+      units: "seconds since 1970-01-01T00:00:00Z"
+
+    - name: "MetaData/dataReceiptTime"
+      source: variables/dataReceiptTime
+      longName: "Observation Receipt Time"
+      units: "seconds since 1970-01-01T00:00:00Z"
+
+    - name: "MetaData/latitude"
+      source: variables/latitude
+      longName: "Latitude"
+      units: "degrees_north"
+      range: [ -90, 90 ]
+
+    - name: "MetaData/longitude"
+      source: variables/longitude
+      longName: "Longitude"
+      units: "degrees_east"
+      range: [ -180, 180 ]
+
+    - name: "MetaData/satelliteIdentifier"
+      source: variables/satelliteId
+      longName: "Satellite Identifier"
+
+    - name: "MetaData/qualityFlags"
+      source: variables/qualityFlags
+      longName: "Quality Flags"
+      units: "1"
+
+    - name: "ObsValue/windDirection"
+      source: variables/windDirectionAt10M
+      longName: "10-meter Wind Direction"
+      units: "degree"
+
+    - name: "ObsValue/windSpeed"
+      source: variables/windSpeedAt10M
+      longName: "10-meter Wind Speed"
+      units: "m s-1"


### PR DESCRIPTION
This PR addes two files for ASCAT
- mapping YAML
- Python  script  --- pass Python coding norm check

Notes:
- This PR should be tested with [bufr-query PR #73](https://github.com/NOAA-EMC/bufr-query/pull/73)
- A new PR will be opened to modify the standalone AMV converters accordingly after this PR is merged.  

ASCAT data processing has the following features:
- Convert wind speed and direction to u and v wind components
- Add obs type (290)

Documentation is in Sphinx style 

Test: script2netcdf validated
Validation plots

IODA windEastward 

![gdas_ObsValue_windEastward_satwnd_ascat_metop-b](https://github.com/user-attachments/assets/3d71ed27-1d94-4df6-a3e1-a230dca6a9d1)

GSI windEastward

![gdas_ObsValue_windEastward_ascatw_ascat_metop-b](https://github.com/user-attachments/assets/35473373-4236-4031-985b-0c118529315c)


IODA windNorthward

![gdas_ObsValue_windNorthward_satwnd_ascat_metop-b](https://github.com/user-attachments/assets/a753cdfe-2bac-461f-a418-078ac0ceaa41)


GSI windNorthward
![gdas_ObsValue_windNorthward_ascatw_ascat_metop-b](https://github.com/user-attachments/assets/5e49b097-007a-46d7-a9c2-0c13274fd819)
