### PR TITLE
Modify satwnd amv converters to functions from imports

### DIFF
--- a/dump/mapping/bufr_satwnd_amv_abi.py
+++ b/dump/mapping/bufr_satwnd_amv_abi.py
@@ -4,8 +4,8 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import add_main_functions
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder, map_path
+from bufr.obs_builder import add_main_functions, map_path
+from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
 MAPPING_PATH = map_path('bufr_satwnd_amv_abi.yaml')

--- a/dump/mapping/bufr_satwnd_amv_abi.yaml
+++ b/dump/mapping/bufr_satwnd_amv_abi.yaml
@@ -39,9 +39,11 @@ bufr:
 
     sensorCentralFrequency:
       query: "*/SCCF"
+      type: float
 
     pressure:
       query: "*/PRLC[1]"
+      type: float
 
     # Processing Center
     dataProviderOrigin:
@@ -50,10 +52,12 @@ bufr:
     # Quality Information - Quality Indicator  
     qualityInformationWithoutForecast:
       query: '*/AMVQIC{2}/PCCF'
+      type: float
 
     # Quality Information - Expected Error  
     expectedError:
       query: '*/AMVQIC{4}/PCCF'
+      type: float
 
     # Derived Motion Wind (DMW) Intermediate Vectors - Coefficient of Variation
     coefficientOfVariation:
@@ -70,6 +74,7 @@ bufr:
     # ObsValue - Wind Direction
     windDirection:
       query: '*/WDIR'
+      type: float
 
     # ObsValue - Wind Speed
     windSpeed:
@@ -85,10 +90,6 @@ bufr:
           _272: goes-18 
 
 encoder:
-# type: netcdf
-
-# dimensions:
-
   globals:
     - name: "platformCommonName"
       type: string

--- a/dump/mapping/bufr_satwnd_amv_abi.yaml
+++ b/dump/mapping/bufr_satwnd_amv_abi.yaml
@@ -165,6 +165,7 @@ encoder:
     - name: "MetaData/qiWithoutForecast"
       source: variables/qualityInformationWithoutForecast
       longName: "Quality Information Without Forecast"
+      units: "percent"
 
     - name: "MetaData/expectedError"
       source: variables/expectedError

--- a/dump/mapping/bufr_satwnd_amv_abi.yaml
+++ b/dump/mapping/bufr_satwnd_amv_abi.yaml
@@ -91,25 +91,33 @@ bufr:
 
 encoder:
   globals:
+    - name: "description"
+      type: string
+      value: "Atmospheric Motion Vectors (AMVs) derived from GOES ABI using five spectral bands: longwave IR (LWIR), shortwave IR (SWIR), water vapor/deep layer (WV/DL), water vapor/cloud top (WVCT) and visible"
+ 
     - name: "platformCommonName"
       type: string
       value: "GOES"
 
     - name: "platformLongDescription"
       type: string
-      value: "Geostationary Operational Satellite"
+      value: "Geostationary Operational Environmental Satellite"
 
-    - name: "sensor"
+    - name: "sensorCommonName"
       type: string
-      value: "Advanced Baseline Imager - ABI"
+      value: "ABI"
+
+    - name: "sensorLongDescription"
+      type: string
+      value: "Advanced Baseline Imager with 16 channels, balanced VIS, NIR, SWIR, MWIR and LWIR"
 
     - name: "source"
       type: string
-      value: "NCEP BUFR Dump for satellite derived atmospheric motion vectors (satwnd)"
+      value: "U.S. National Weather Service, National Centres for Environmental Prediction (NCEP))"
 
-    - name: "providerFullName"
+    - name: "sourceFiles"
       type: string
-      value: "National Environmental Satellite, Data, and Information Service"
+      value: "NCEP BUFR Dump - satwnd: NC005030 (LWIR), NC005031(WV/DL), NC005032(VIS), NC005034(WV/CT), NC005039(SWIR) "
 
     - name: "processingLevel"
       type: string
@@ -117,7 +125,7 @@ encoder:
 
     - name: "converter"
       type: string
-      value: "BUFR"
+      value: "bufr-query"
 
   variables:
     # MetaData 
@@ -167,14 +175,16 @@ encoder:
       longName: "Quality Information Without Forecast"
       units: "percent"
 
+      # To DO: change to MetaData/windPercentConfidence (dimension: Location) 
     - name: "MetaData/expectedError"
       source: variables/expectedError
       longName: "Expected Error"
-      units: "m s-1"
+      units: "percent"
 
     - name: "MetaData/coefficientOfVariation"
       source: variables/coefficientOfVariation
-      longName: "Coefficient of Variation"
+      longName: "Coefficient of Variation - a measure of the variability of AMV data relative to its average value (large coefficients mean high uncertainity)"
+      units: "1"
 
     - name: "MetaData/windComputationMethod"
       source: variables/windComputationMethod
@@ -187,7 +197,7 @@ encoder:
     - name: "MetaData/pressure"
       source: variables/pressure
       longName: "Pressure"
-      units: "pa"
+      units: "Pa"
 
     - name: "ObsValue/windDirection"
       source: variables/windDirection

--- a/dump/mapping/bufr_satwnd_amv_ahi.py
+++ b/dump/mapping/bufr_satwnd_amv_ahi.py
@@ -4,8 +4,8 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import add_main_functions
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder, map_path
+from bufr.obs_builder import add_main_functions, map_path
+from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
 MAPPING_PATH = map_path('bufr_satwnd_amv_ahi.yaml')

--- a/dump/mapping/bufr_satwnd_amv_ahi.yaml
+++ b/dump/mapping/bufr_satwnd_amv_ahi.yaml
@@ -29,9 +29,11 @@ bufr:
 
     sensorCentralFrequency:
       query: "*/SCCF"
+      type: float
 
     pressure:
       query: "*/PRLC"
+      type: float
 
     # Processing Center
     dataProviderOrigin:
@@ -44,6 +46,7 @@ bufr:
     # Quality Information - contains multiple types
     qualityInformation:
       query: '*/QCPRMS[1]/PCCF'
+      type: float
 
     # Wind Retrieval Method Information - Computation 
     windComputationMethod:
@@ -52,6 +55,7 @@ bufr:
     # ObsValue - Wind Direction
     windDirection:
       query: '*/WDIR'
+      type: float
 
     # ObsValue - Wind Speed
     windSpeed:
@@ -66,10 +70,6 @@ bufr:
           _174: h9  
 
 encoder:
-# type: netcdf
-
-# dimensions:
-
   globals:
     - name: "platformCommonName"
       type: string

--- a/dump/mapping/bufr_satwnd_amv_ahi.yaml
+++ b/dump/mapping/bufr_satwnd_amv_ahi.yaml
@@ -71,25 +71,33 @@ bufr:
 
 encoder:
   globals:
+    - name: "description"
+      type: string
+      value: "Atmospheric Motion Vectors (AMVs) derived from HIMAWARI AHI using three spectral bands: longwave IR (LWIR), water vapor/cloud top (WVCT) and visible"
+
     - name: "platformCommonName"
       type: string
       value: "Himawari"
 
     - name: "platformLongDescription"
       type: string
-      value: "Geostationary Operational Satellite"
+      value: "Series of 2 operational meteorological satellites in geostationary orbit"
 
-    - name: "sensor"
+    - name: "sensorCommonName"
       type: string
-      value: "Advanced Himawari Imager"
+      value: "AHI"
+
+    - name: "sensorLongDescription"
+      type: string
+      value: "Advanced Himawari Imager with 16 channels, balanced VIS, NIR, SWIR, MWIR and LWIR"
 
     - name: "source"
       type: string
-      value: "NCEP BUFR Dump for satellite derived atmospheric motion vectors (satwnd)"
+      value: "U.S. National Weather Service, National Centres for Environmental Prediction (NCEP))"
 
-    - name: "providerFullName"
+    - name: "sourceFiles"
       type: string
-      value: "Japan Meteorological Agency"
+      value: "NCEP BUFR Dump - satwnd: NC005044 (LWIR), NC005045(VIS), NC005046(WV/CT)"
 
     - name: "processingLevel"
       type: string
@@ -97,7 +105,7 @@ encoder:
 
     - name: "converter"
       type: string
-      value: "BUFR"
+      value: "bufr-query"
 
   variables:
 
@@ -145,7 +153,7 @@ encoder:
     - name: "MetaData/pressure"
       source: variables/pressure
       longName: "Pressure"
-      units: "pa"
+      units: "Pa"
 
     - name: "ObsValue/windDirection"
       source: variables/windDirection

--- a/dump/mapping/bufr_satwnd_amv_avhrr.py
+++ b/dump/mapping/bufr_satwnd_amv_avhrr.py
@@ -4,8 +4,8 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import add_main_functions
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder, map_path
+from bufr.obs_builder import add_main_functions, map_path
+from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
 MAPPING_PATH = map_path('bufr_satwnd_amv_avhrr.yaml')

--- a/dump/mapping/bufr_satwnd_amv_avhrr.py
+++ b/dump/mapping/bufr_satwnd_amv_avhrr.py
@@ -49,8 +49,14 @@ class SatWndAmvAvhrrObsBuilder(SatWndAmvObsBuilder):
         satId = container.get('satelliteId', cat)
 
         if not satId.size:
-            add_dummy_variable(container, 'windGeneratingApplication', cat, 'windComputationMethod')
-            add_dummy_variable(container, 'qualityInformationWithoutForecast', cat, 'windSpeed')
+
+            dummy_mappings = [
+                ('windGeneratingApplication', 'windComputationMethod'),
+                ('qualityInformationWithoutForecast', 'windSpeed')
+            ]
+            for target_var, source_var in dummy_mappings:
+                add_dummy_variable(container, target_var, cat, source_var)
+
             return
 
         gnap, qifn = self._get_avhrr_quality_info_and_gen_app(gnap2D, pccf2D, satId)

--- a/dump/mapping/bufr_satwnd_amv_avhrr.py
+++ b/dump/mapping/bufr_satwnd_amv_avhrr.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import add_main_functions, map_path
+from bufr.obs_builder import add_main_functions, map_path, add_dummy_variable
 from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
@@ -49,10 +49,8 @@ class SatWndAmvAvhrrObsBuilder(SatWndAmvObsBuilder):
         satId = container.get('satelliteId', cat)
 
         if not satId.size:
-            paths = container.get_paths('windComputationMethod', cat)
-            dummy = container.get('windSpeed', cat)
-            container.add('windGeneratingApplication', dummy, paths, cat)
-            container.add('qualityInformationWithoutForecast', dummy, paths, cat)
+            add_dummy_variable(container, 'windGeneratingApplication', cat, 'windComputationMethod')
+            add_dummy_variable(container, 'qualityInformationWithoutForecast', cat, 'windSpeed')
             return
 
         gnap, qifn = self._get_avhrr_quality_info_and_gen_app(gnap2D, pccf2D, satId)
@@ -89,6 +87,7 @@ class SatWndAmvAvhrrObsBuilder(SatWndAmvObsBuilder):
             # dataset. In that case, we need to actually set findQI=1 and findEE=4 here.
             # Let's do a preliminary check to see if any gnap2D values match findQI. If not, let's
             # automatically switch to findQI=1, findEE=4 and presume pre-2023 EUMETSAT AVHRR format
+            # If findQI is not found anywhere in gnap2D, set findQI and findEE to 1 and 4, respectively
             if not np.any(np.isin(gnap2D, [findQI])):
                 self.log.debug(
                     f'NO GNAP VALUE OF {findQI} EXISTS FOR EUMETSAT AVHRR DATASET, PRESUMING PRE-2023 FORMATTING')
@@ -112,18 +111,17 @@ class SatWndAmvAvhrrObsBuilder(SatWndAmvObsBuilder):
         gnap = None
         qifn = None
         for i in range(gDim2):
-            if np.unique(gnap2D[:, i].squeeze()) == findQI:
-                if i <= qDim2:
+            if np.unique(gnap2D[:, i]) == findQI:
+                if i < qDim2:
                     self.log.info(f'GNAP/PCCF found for column {i}')
-                    gnap = gnap2D[:, i].squeeze()
-                    qifn = pccf2D[:, i].squeeze()
+                    gnap = gnap2D[:, i].copy()
+                    qifn = pccf2D[:, i].copy()
                 else:
                     self.log.info(f'ERROR: GNAP column {i} outside of PCCF dimension {qDim2}')
         if (gnap is None) and (qifn is None):
             raise ValueError(f'GNAP == {findQI} NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
         # If EE is needed, key search on np.unique(gnap2D[:,i].squeeze()) == findEE instead
-        # NOTE: Make sure to return np.float32 or np.int32 types as appropriate!!!
-        return gnap.astype(np.int32), qifn.astype(np.int32)
+        return gnap, qifn
 
 
 # Add main functions create_obs_file and create_obs_group

--- a/dump/mapping/bufr_satwnd_amv_avhrr.yaml
+++ b/dump/mapping/bufr_satwnd_amv_avhrr.yaml
@@ -30,10 +30,12 @@ bufr:
 
     sensorCentralFrequency:
       query: "*/SCCF"
+      type: float
 
     pressure:
       # [NESDIS, EUMETSAT]
       query: "[*/PRLC, */PRLC[1]]"
+      type: float
 
     # Processing Center
     dataProviderOrigin:
@@ -49,6 +51,7 @@ bufr:
     qualityInformation:
       # [NESDIS, EUMETSAT]
       query: "[*/GQCPRMS/PCCF, */AMVQIC/PCCF]"
+      type: float
 
     # Wind Retrieval Method Information - Computation 
     windComputationMethod:
@@ -57,6 +60,7 @@ bufr:
     # ObsValue - Wind Direction
     windDirection:
       query: '*/WDIR'
+      type: float
 
     # ObsValue - Wind Speed
     windSpeed:
@@ -75,10 +79,6 @@ bufr:
           _223: n19
 
 encoder:
-# type: netcdf
-
-# dimensions:
-
   globals:
     - name: "platformCommonName"
       type: string

--- a/dump/mapping/bufr_satwnd_amv_avhrr.yaml
+++ b/dump/mapping/bufr_satwnd_amv_avhrr.yaml
@@ -80,25 +80,33 @@ bufr:
 
 encoder:
   globals:
+    - name: "description"
+      type: string
+      value: "Atmospheric Motion Vectors (AMVs) derived from AVHRR using longwave IR (LWIR) spectral band"
+
     - name: "platformCommonName"
       type: string
-      value: "EUMETSAT: METOP, NESDIS: NOAA"
+      value: "EUMETSAT MetOp and NESDIS NOAA series"
 
     - name: "platformLongDescription"
       type: string
-      value: "Low-Earth Orbiting Operational Satellite"
+      value: "Low-Earth Orbiting Operational Satellites - MetOp and NOAA series"
 
-    - name: "sensor"
+    - name: "sensorCommonName"
       type: string
-      value: "Advanced Very High Resolution Radiometer"
+      value: "AVHRR"
+
+    - name: "sensorLongDescription"
+      type: string
+      value: "Advanced Very High Resolution Radiometer with 6-channel radiometer covering VIS, NIR, SWIR, MWIR and TIR; cross-scanning"
 
     - name: "source"
       type: string
-      value: "NCEP BUFR Dump for satellite derived atmospheric motion vectors (satwnd)"
+      value: "U.S. National Weather Service, National Centres for Environmental Prediction (NCEP))"
 
-    - name: "providerFullName"
+    - name: "sourceFiles"
       type: string
-      value: "EUMETSAT: European Organisation for the Exploitation of Meteorological Satellites, NESDIS: National Environmental Satellite, Data, and Information Service"
+      value: "NCEP BUFR Dump - satwnd (before 2023): NC005080 (NOAA, MetOp); satwnd(after 2023): NC005080 (NOAA), NC005081 (MetOp)"
 
     - name: "processingLevel"
       type: string
@@ -106,7 +114,7 @@ encoder:
 
     - name: "converter"
       type: string
-      value: "BUFR"
+      value: "bufr-query"
 
   variables:
 
@@ -154,7 +162,7 @@ encoder:
     - name: "MetaData/pressure"
       source: variables/pressure
       longName: "Pressure"
-      units: "pa"
+      units: "Pa"
 
     - name: "ObsValue/windDirection"
       source: variables/windDirection

--- a/dump/mapping/bufr_satwnd_amv_leogeo.py
+++ b/dump/mapping/bufr_satwnd_amv_leogeo.py
@@ -4,8 +4,8 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import add_main_functions
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder, map_path
+from bufr.obs_builder import add_main_functions, map_path
+from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
 MAPPING_PATH = map_path('bufr_satwnd_amv_leogeo.yaml')

--- a/dump/mapping/bufr_satwnd_amv_leogeo.yaml
+++ b/dump/mapping/bufr_satwnd_amv_leogeo.yaml
@@ -27,9 +27,11 @@ bufr:
 
     sensorCentralFrequency:
       query: "*/SCCF"
+      type: float
 
     pressure:
       query: "*/PRLC[1]"
+      type: float
 
     # Processing Center
     dataProviderOrigin:
@@ -42,6 +44,7 @@ bufr:
     # Quality Information Without Forecast
     qualityInformationWithoutForecast:
       query: '*/LGRSQ4[1]{1}/PCCF'
+      type: float
 
     # Wind Retrieval Method Information - Computation 
     windComputationMethod:
@@ -50,6 +53,7 @@ bufr:
     # ObsValue - Wind Direction
     windDirection:
       query: '*/WDIR'
+      type: float
 
     # ObsValue - Wind Speed
     windSpeed:
@@ -146,6 +150,7 @@ encoder:
     - name: "MetaData/qiWithoutForecast"
       source: variables/qualityInformationWithoutForecast
       longName: "Quality Information Without Forecast"
+      units: "percent"
 
     - name: "MetaData/pressure"
       source: variables/pressure

--- a/dump/mapping/bufr_satwnd_amv_leogeo.yaml
+++ b/dump/mapping/bufr_satwnd_amv_leogeo.yaml
@@ -67,10 +67,6 @@ bufr:
           _854: multi 
 
 encoder:
-# type: netcdf
-
-# dimensions:
-
   globals:
     - name: "platformCommonName"
       type: string

--- a/dump/mapping/bufr_satwnd_amv_leogeo.yaml
+++ b/dump/mapping/bufr_satwnd_amv_leogeo.yaml
@@ -68,25 +68,33 @@ bufr:
 
 encoder:
   globals:
+    - name: "description"
+      type: string
+      value: "High-latitude Atmospheric Motion Vectors (AMVs) derived from combined geostationary and low-earth polar-orbiting satellite imagery"
+
     - name: "platformCommonName"
       type: string
-      value: "LEOGEO"
+      value: "MultiSats"
 
     - name: "platformLongDescription"
       type: string
-      value: "Combined Geostationary/Low-Earth Orbiting Operational Satellite(s)"
+      value: "Combined Geostationary/Low-Earth Orbiting Operational Satellites"
 
-    - name: "sensor"
+    - name: "sensorCommonName"
       type: string
-      value: "Multiple"
+      value: "LEOGEO"
+
+    - name: "sensorLongDescription"
+      type: string
+      value: "Multiple sensors from geostationary and low-earth orbiting satellites"
 
     - name: "source"
       type: string
-      value: "NCEP BUFR Dump for satellite derived atmospheric motion vectors (satwnd)"
+      value: "U.S. National Weather Service, National Centres for Environmental Prediction (NCEP))"
 
-    - name: "providerFullName"
+    - name: "sourceFiles"
       type: string
-      value: "National Environmental Satellite, Data, and Information Service"
+      value: "NCEP BUFR Dump - satwnd NC005072"
 
     - name: "processingLevel"
       type: string
@@ -94,7 +102,7 @@ encoder:
 
     - name: "converter"
       type: string
-      value: "BUFR"
+      value: "bufr-query"
 
   variables:
 
@@ -151,7 +159,7 @@ encoder:
     - name: "MetaData/pressure"
       source: variables/pressure
       longName: "Pressure"
-      units: "pa"
+      units: "Pa"
 
     - name: "ObsValue/windDirection"
       source: variables/windDirection

--- a/dump/mapping/bufr_satwnd_amv_modis.py
+++ b/dump/mapping/bufr_satwnd_amv_modis.py
@@ -4,8 +4,8 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import add_main_functions
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder, map_path
+from bufr.obs_builder import add_main_functions, map_path
+from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
 MAPPING_PATH = map_path('bufr_satwnd_amv_modis.yaml')

--- a/dump/mapping/bufr_satwnd_amv_modis.yaml
+++ b/dump/mapping/bufr_satwnd_amv_modis.yaml
@@ -28,9 +28,11 @@ bufr:
 
     sensorCentralFrequency:
       query: "*/SCCF"
+      type: float
 
     pressure:
       query: "*/PRLC"
+      type: float
 
     # Processing Center
     dataProviderOrigin:
@@ -43,6 +45,7 @@ bufr:
     # Quality Information - contains multiple types
     qualityInformation:
       query: '*/GQCPRMS[1]/PCCF'
+      type: float
 
     # Wind Retrieval Method Information - Computation 
     windComputationMethod:
@@ -51,6 +54,7 @@ bufr:
     # ObsValue - Wind Direction
     windDirection:
       query: '*/WDIR'
+      type: float
 
     # ObsValue - Wind Speed
     windSpeed:

--- a/dump/mapping/bufr_satwnd_amv_modis.yaml
+++ b/dump/mapping/bufr_satwnd_amv_modis.yaml
@@ -70,25 +70,33 @@ bufr:
 
 encoder:
   globals:
+    - name: "description"
+      type: string
+      value: "Atmospheric Motion Vectors (AMVs) derived from MODIS using three spectral bands: longwave IR (LWIR), water vapor/cloud top (WVCT) and water vapor/deep layer (WVDL)"
+
     - name: "platformCommonName"
       type: string
       value: "Terra/Aqua"
 
     - name: "platformLongDescription"
       type: string
-      value: "Low-Earth Orbiting Operational Satellite"
+      value: "TERRA and Aqua from NASA Earth Observation System"
 
-    - name: "sensor"
+    - name: "sensorCommonName"
       type: string
-      value: "Moderate Resolution Imaging Spectroradiometer"
+      value: "MODIS"
+
+    - name: "sensorLongDescription"
+      type: string
+      value: "Moderate Resolution Imaging Spectroradiometer with 36-channel VIS/IR spectro-radiometer; cross-scanning"
 
     - name: "source"
       type: string
-      value: "NCEP BUFR Dump for satellite derived atmospheric motion vectors (satwnd)"
+      value: "U.S. National Weather Service, National Centres for Environmental Prediction (NCEP))"
 
-    - name: "providerFullName"
+    - name: "sourceFiles"
       type: string
-      value: "National Environmental Satellite, Data, and Information Service"
+      value: "NCEP BUFR Dump - satwnd: NC005070 (TERRA) NC005071 (AQUA)"
 
     - name: "processingLevel"
       type: string
@@ -96,7 +104,7 @@ encoder:
 
     - name: "converter"
       type: string
-      value: "BUFR"
+      value: "bufr-query"
 
   variables:
 
@@ -144,7 +152,7 @@ encoder:
     - name: "MetaData/pressure"
       source: variables/pressure
       longName: "Pressure"
-      units: "pa"
+      units: "Pa"
 
     - name: "ObsValue/windDirection"
       source: variables/windDirection

--- a/dump/mapping/bufr_satwnd_amv_modis.yaml
+++ b/dump/mapping/bufr_satwnd_amv_modis.yaml
@@ -69,10 +69,6 @@ bufr:
           _784: aqua
 
 encoder:
-# type: netcdf
-
-# dimensions:
-
   globals:
     - name: "platformCommonName"
       type: string

--- a/dump/mapping/bufr_satwnd_amv_obs_builder.py
+++ b/dump/mapping/bufr_satwnd_amv_obs_builder.py
@@ -5,11 +5,7 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import ObsBuilder
-
-
-def map_path(map_file_name):
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(script_dir, map_file_name)
+from bufr.transforms import compute_wind_components 
 
 
 class SatWndAmvObsBuilder(ObsBuilder):
@@ -129,7 +125,7 @@ class SatWndAmvObsBuilder(ObsBuilder):
         self.log.debug(f'wdir min/max = {wdir.min()} {wdir.max()}')
         self.log.debug(f'wspd min/max = {wspd.min()} {wspd.max()}')
 
-        uob, vob = self._compute_wind_components(wdir, wspd)
+        uob, vob = compute_wind_components(wspd, wdir)
 
         self.log.debug(f'uob min/max = {uob.min()} {uob.max()}')
         self.log.debug(f'vob min/max = {vob.min()} {vob.max()}')
@@ -178,23 +174,6 @@ class SatWndAmvObsBuilder(ObsBuilder):
         raise NotImplementedError('Method _get_obs_type must be implemented in derived classes')
 
     # Private methods
-    def _compute_wind_components(self, wdir, wspd):
-        """
-        Compute the U and V wind components from wind direction and wind speed.
-
-        Parameters:
-            wdir (array-like): Wind direction in degrees (meteorological convention: 0° = North, 90° = East).
-            wspd (array-like): Wind speed.
-
-        Returns:
-            tuple: U and V wind components as numpy arrays with dtype float32.
-        """
-        wdir_rad = np.radians(wdir)  # Convert degrees to radians
-        u = -wspd * np.sin(wdir_rad)
-        v = -wspd * np.cos(wdir_rad)
-
-        return u.astype(np.float32), v.astype(np.float32)
-
     def _get_quality_info_and_gen_app(self, findQi, gnap2D, pccf2D):
         # For NOAA VIIRS data, qi w/o forecast (qifn) is packaged in same
         # vector of qi with ga = 5 (EUMETSAT QI without forecast). Must
@@ -204,8 +183,8 @@ class SatWndAmvObsBuilder(ObsBuilder):
         gDim1, gDim2 = np.shape(gnap2D)
         qDim1, qDim2 = np.shape(pccf2D)
         self.log.info('Generating Application and Quality Information SEARCH')
-        self.log.debug(f'Dimension size of GNAP ({gDim1},{gDim2})')
-        self.log.debug(f'Dimension size of PCCF ({qDim1},{qDim2})')
+        self.log.debug( f'Dimension size of GNAP ({gDim1},{gDim2})')
+        self.log.debug( f'Dimension size of PCCF ({qDim1},{qDim2})')
 
         # 2. Initialize gnap and qifn as None, and search for dimension of
         #    ga with values of 5. If the same column exists for qi, assign

--- a/dump/mapping/bufr_satwnd_amv_obs_builder.py
+++ b/dump/mapping/bufr_satwnd_amv_obs_builder.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import ObsBuilder, add_dummy_variable
-from bufr.transforms import compute_wind_components 
+from bufr.transforms import compute_wind_components
 
 
 class SatWndAmvObsBuilder(ObsBuilder):
@@ -103,7 +103,7 @@ class SatWndAmvObsBuilder(ObsBuilder):
     def _add_wind_obs(self, container, cat):
 
         satId = container.get('satelliteId', cat)
-        if not satId.size: 
+        if not satId.size:
             self.log.warning(f'category {cat[0]} does not exist in input file')
             add_dummy_variable(container, 'obstype_uwind', cat, 'windComputationMethod')
             add_dummy_variable(container, 'obstype_vwind', cat, 'windComputationMethod')
@@ -153,7 +153,6 @@ class SatWndAmvObsBuilder(ObsBuilder):
         container.add('height', height, paths, cat)
         container.add('stationElevation', stnelev, paths, cat)
 
-
     def _add_quality_info_and_gen_app(self, findQi, container, cat):
         # Add new variables: MetaData/windGeneratingApplication and qiWithoutForecast
         gnap2D = container.get('generatingApplication', cat)
@@ -173,7 +172,6 @@ class SatWndAmvObsBuilder(ObsBuilder):
         container.add('windGeneratingApplication', gnap, paths, cat)
         paths = container.get_paths('windSpeed', cat)
         container.add('qualityInformationWithoutForecast', qifn, paths, cat)
-
 
     def _get_obs_type(self, swcm, chan_freq=0):
         """
@@ -202,8 +200,8 @@ class SatWndAmvObsBuilder(ObsBuilder):
         gDim1, gDim2 = np.shape(gnap2D)
         qDim1, qDim2 = np.shape(pccf2D)
         self.log.info('Generating Application and Quality Information SEARCH')
-        self.log.debug( f'Dimension size of GNAP ({gDim1},{gDim2})')
-        self.log.debug( f'Dimension size of PCCF ({qDim1},{qDim2})')
+        self.log.debug(f'Dimension size of GNAP ({gDim1},{gDim2})')
+        self.log.debug(f'Dimension size of PCCF ({qDim1},{qDim2})')
 
         # 2. Initialize gnap and qifn as None, and search for dimension of
         #    ga with values of 5. If the same column exists for qi, assign

--- a/dump/mapping/bufr_satwnd_amv_obs_builder.py
+++ b/dump/mapping/bufr_satwnd_amv_obs_builder.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import ObsBuilder, add_dummy_variable
-from bufr.transforms import compute_wind_components
+from bufr.transforms import compute_wind_components 
 
 
 class SatWndAmvObsBuilder(ObsBuilder):
@@ -81,6 +81,7 @@ class SatWndAmvObsBuilder(ObsBuilder):
                 'name': 'MetaData/stationElevation',
                 'source': 'stationElevation',
                 'units': 'm',
+                'longName': 'Station Elevation',
             }])
 
     def _add_quality_info_and_gen_app_descriptions(self, description):
@@ -94,7 +95,7 @@ class SatWndAmvObsBuilder(ObsBuilder):
             {
                 'name': 'MetaData/qiWithoutForecast',
                 'source': 'qualityInformationWithoutForecast',
-                'units': '1',
+                'units': 'percent',
                 'longName': 'Quality Information Without Forecast',
             }])
 
@@ -102,7 +103,7 @@ class SatWndAmvObsBuilder(ObsBuilder):
     def _add_wind_obs(self, container, cat):
 
         satId = container.get('satelliteId', cat)
-        if not satId.size:
+        if not satId.size: 
             self.log.warning(f'category {cat[0]} does not exist in input file')
             add_dummy_variable(container, 'obstype_uwind', cat, 'windComputationMethod')
             add_dummy_variable(container, 'obstype_vwind', cat, 'windComputationMethod')
@@ -152,6 +153,7 @@ class SatWndAmvObsBuilder(ObsBuilder):
         container.add('height', height, paths, cat)
         container.add('stationElevation', stnelev, paths, cat)
 
+
     def _add_quality_info_and_gen_app(self, findQi, container, cat):
         # Add new variables: MetaData/windGeneratingApplication and qiWithoutForecast
         gnap2D = container.get('generatingApplication', cat)
@@ -164,13 +166,14 @@ class SatWndAmvObsBuilder(ObsBuilder):
             return
 
         gnap, qifn = self._get_quality_info_and_gen_app(findQi, gnap2D, pccf2D)
-
         self.log.debug(f'gnap min/max = {gnap.min()} {gnap.max()}')
         self.log.debug(f'qifn min/max = {qifn.min()} {qifn.max()}')
 
         paths = container.get_paths('windComputationMethod', cat)
         container.add('windGeneratingApplication', gnap, paths, cat)
+        paths = container.get_paths('windSpeed', cat)
         container.add('qualityInformationWithoutForecast', qifn, paths, cat)
+
 
     def _get_obs_type(self, swcm, chan_freq=0):
         """
@@ -199,8 +202,8 @@ class SatWndAmvObsBuilder(ObsBuilder):
         gDim1, gDim2 = np.shape(gnap2D)
         qDim1, qDim2 = np.shape(pccf2D)
         self.log.info('Generating Application and Quality Information SEARCH')
-        self.log.debug(f'Dimension size of GNAP ({gDim1},{gDim2})')
-        self.log.debug(f'Dimension size of PCCF ({qDim1},{qDim2})')
+        self.log.debug( f'Dimension size of GNAP ({gDim1},{gDim2})')
+        self.log.debug( f'Dimension size of PCCF ({qDim1},{qDim2})')
 
         # 2. Initialize gnap and qifn as None, and search for dimension of
         #    ga with values of 5. If the same column exists for qi, assign
@@ -209,15 +212,14 @@ class SatWndAmvObsBuilder(ObsBuilder):
         gnap = None
         qifn = None
         for i in range(gDim2):
-            if np.unique(gnap2D[:, i].squeeze()) == findQi:
-                if i <= qDim2:
+            if np.all(np.unique(gnap2D[:, i]) == findQi):
+                if i < qDim2:
                     self.log.info(f'GNAP/PCCF found for column {i}')
-                    gnap = gnap2D[:, i].squeeze()
-                    qifn = pccf2D[:, i].squeeze()
+                    gnap = gnap2D[:, i].copy()
+                    qifn = pccf2D[:, i].copy()
                 else:
                     self.log.info(f'ERROR: GNAP column {i} outside of PCCF dimension {qDim2}')
         if (gnap is None) & (qifn is None):
             raise ValueError(f'GNAP == {findQi} NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
         # If EE is needed, key search on np.unique(gnap2D[:,i].squeeze()) == 7 instead
-        # NOTE: Make sure to return np.float32 or np.int32 types as appropriate!!!
-        return gnap.astype(np.int32), qifn.astype(np.int32)
+        return gnap, qifn

--- a/dump/mapping/bufr_satwnd_amv_obs_builder.py
+++ b/dump/mapping/bufr_satwnd_amv_obs_builder.py
@@ -4,8 +4,8 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import ObsBuilder
-from bufr.transforms import compute_wind_components 
+from bufr.obs_builder import ObsBuilder, add_dummy_variable
+from bufr.transforms import compute_wind_components
 
 
 class SatWndAmvObsBuilder(ObsBuilder):
@@ -26,14 +26,14 @@ class SatWndAmvObsBuilder(ObsBuilder):
             self.log.debug(f'category = {cat}')
 
             satId = container.get('satelliteId', cat)
-            if not np.any(satId):
+            if not satId.size:
                 self.log.warning(f'category {cat[0]} does not exist in input file')
 
             self._add_wind_obs(container, cat)
 
         # Check
         self.log.debug(f'container list (updated): {container.list()}')
-        self.log.debug('all_sub_categories {container.all_sub_categories()}')
+        self.log.debug(f'all_sub_categories {container.all_sub_categories()}')
 
         return container
 
@@ -70,6 +70,17 @@ class SatWndAmvObsBuilder(ObsBuilder):
                 'source': 'windNorthward',
                 'units': 'm s-1',
                 'longName': 'Northward Wind Component',
+            },
+            {
+                'name': 'MetaData/height',
+                'source': 'height',
+                'units': 'm',
+                'longName': 'Height of Observation',
+            },
+            {
+                'name': 'MetaData/stationElevation',
+                'source': 'stationElevation',
+                'units': 'm',
             }])
 
     def _add_quality_info_and_gen_app_descriptions(self, description):
@@ -89,24 +100,22 @@ class SatWndAmvObsBuilder(ObsBuilder):
 
     # Methods that are used to extend the obs data container
     def _add_wind_obs(self, container, cat):
-        # Add new variables: ObsType/windEastward & ObsType/windNorthward
-        swcm = container.get('windComputationMethod', cat)
-        chanfreq = container.get('sensorCentralFrequency', cat)
 
-        if swcm.size == 0:
+        satId = container.get('satelliteId', cat)
+        if not satId.size:
             self.log.warning(f'category {cat[0]} does not exist in input file')
-            paths = container.get_paths('variables/windComputationMethod', cat)
-            obstype = container.get('variables/windComputationMethod', cat)
-            container.add('variables/obstype_uwind', obstype, paths, cat)
-            container.add('variables/obstype_vwind', obstype, paths, cat)
-
-            paths = container.get_paths('variables/windSpeed', cat)
-            wob = container.get('variables/windSpeed', cat)
-            container.add('variables/windEastward', wob, paths, cat)
-            container.add('variables/windNorthward', wob, paths, cat)
+            add_dummy_variable(container, 'obstype_uwind', cat, 'windComputationMethod')
+            add_dummy_variable(container, 'obstype_vwind', cat, 'windComputationMethod')
+            add_dummy_variable(container, 'windEastward', cat, 'windSpeed')
+            add_dummy_variable(container, 'windNorthward', cat, 'windSpeed')
+            add_dummy_variable(container, 'height', cat, 'pressure')
+            add_dummy_variable(container, 'stationElevation', cat, 'pressure')
             return
 
-        # self.log.debug(f'swcm min/max = {swcm.min()} {swcm.max()}')
+        # Add new ObsType variables: ObsType/windEastward & ObsType/windNorthward
+        swcm = container.get('windComputationMethod', cat)
+        chanfreq = container.get('sensorCentralFrequency', cat)
+        self.log.debug(f'swcm min/max = {swcm.min()} {swcm.max()}')
         self.log.debug('chanfreq min/max = {chanfreq.min()} {chanfreq.max()}')
 
         obstype = self._get_obs_type(swcm, chanfreq)
@@ -118,7 +127,7 @@ class SatWndAmvObsBuilder(ObsBuilder):
         container.add('obstype_uwind', obstype, paths, cat)
         container.add('obstype_vwind', obstype, paths, cat)
 
-        # Add new variables: ObsValue/windEastward & ObsValue/windNorthward
+        # Add new ObsValue variables: ObsValue/windEastward & ObsValue/windNorthward
         wdir = container.get('windDirection', cat)
         wspd = container.get('windSpeed', cat)
 
@@ -134,6 +143,15 @@ class SatWndAmvObsBuilder(ObsBuilder):
         container.add('windEastward', uob, paths, cat)
         container.add('windNorthward', vob, paths, cat)
 
+        # Add new MetaData variables: MetaData/height & MetaData/stationElevation
+        pressure = container.get("pressure", cat)
+        height = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+        stnelev = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
+
+        paths = container.get_paths('pressure', cat)
+        container.add('height', height, paths, cat)
+        container.add('stationElevation', stnelev, paths, cat)
+
     def _add_quality_info_and_gen_app(self, findQi, container, cat):
         # Add new variables: MetaData/windGeneratingApplication and qiWithoutForecast
         gnap2D = container.get('generatingApplication', cat)
@@ -141,10 +159,8 @@ class SatWndAmvObsBuilder(ObsBuilder):
         satId = container.get('satelliteId', cat)
 
         if not satId.size:
-            paths = container.get_paths('windComputationMethod', cat)
-            dummy = container.get('windSpeed', cat)
-            container.add('windGeneratingApplication', dummy, paths, cat)
-            container.add('qualityInformationWithoutForecast', dummy, paths, cat)
+            add_dummy_variable(container, 'windGeneratingApplication', cat, 'windComputationMethod')
+            add_dummy_variable(container, 'qualityInformationWithoutForecast', cat, 'windSpeed')
             return
 
         gnap, qifn = self._get_quality_info_and_gen_app(findQi, gnap2D, pccf2D)
@@ -183,8 +199,8 @@ class SatWndAmvObsBuilder(ObsBuilder):
         gDim1, gDim2 = np.shape(gnap2D)
         qDim1, qDim2 = np.shape(pccf2D)
         self.log.info('Generating Application and Quality Information SEARCH')
-        self.log.debug( f'Dimension size of GNAP ({gDim1},{gDim2})')
-        self.log.debug( f'Dimension size of PCCF ({qDim1},{qDim2})')
+        self.log.debug(f'Dimension size of GNAP ({gDim1},{gDim2})')
+        self.log.debug(f'Dimension size of PCCF ({qDim1},{qDim2})')
 
         # 2. Initialize gnap and qifn as None, and search for dimension of
         #    ga with values of 5. If the same column exists for qi, assign
@@ -201,7 +217,7 @@ class SatWndAmvObsBuilder(ObsBuilder):
                 else:
                     self.log.info(f'ERROR: GNAP column {i} outside of PCCF dimension {qDim2}')
         if (gnap is None) & (qifn is None):
-            raise ValueError(f'GNAP == {findQI} NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
+            raise ValueError(f'GNAP == {findQi} NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
         # If EE is needed, key search on np.unique(gnap2D[:,i].squeeze()) == 7 instead
         # NOTE: Make sure to return np.float32 or np.int32 types as appropriate!!!
         return gnap.astype(np.int32), qifn.astype(np.int32)

--- a/dump/mapping/bufr_satwnd_amv_obs_builder.py
+++ b/dump/mapping/bufr_satwnd_amv_obs_builder.py
@@ -30,6 +30,7 @@ class SatWndAmvObsBuilder(ObsBuilder):
                 self.log.warning(f'category {cat[0]} does not exist in input file')
 
             self._add_wind_obs(container, cat)
+            self._add_metadata(container, cat)
 
         # Check
         self.log.debug(f'container list (updated): {container.list()}')
@@ -41,6 +42,8 @@ class SatWndAmvObsBuilder(ObsBuilder):
     def _make_description(self):
         description = super()._make_description()
         self._add_wind_descriptions(description)
+        self._add_metadata_descriptions(description)
+        self._remove_descriptions(description)
 
         return description
 
@@ -50,13 +53,11 @@ class SatWndAmvObsBuilder(ObsBuilder):
             {
                 'name': 'ObsType/windEastward',
                 'source': 'obstype_uwind',
-                'units': '1',
                 'longName': 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band',
             },
             {
                 'name': 'ObsType/windNorthward',
                 'source': 'obstype_vwind',
-                'units': '1',
                 'longName': 'Observation Type based on Satellite-derived Wind Computation Method and Spectral Band',
             },
             {
@@ -70,7 +71,10 @@ class SatWndAmvObsBuilder(ObsBuilder):
                 'source': 'windNorthward',
                 'units': 'm s-1',
                 'longName': 'Northward Wind Component',
-            },
+            }])
+
+    def _add_metadata_descriptions(self, description):
+        description.add_variables([
             {
                 'name': 'MetaData/height',
                 'source': 'height',
@@ -84,12 +88,15 @@ class SatWndAmvObsBuilder(ObsBuilder):
                 'longName': 'Station Elevation',
             }])
 
+    def _remove_descriptions(self, description):
+        description.remove_variable('ObsValue/windDirection')
+        description.remove_variable('ObsValue/windSpeed')
+
     def _add_quality_info_and_gen_app_descriptions(self, description):
         description.add_variables([
             {
                 'name': 'MetaData/windGeneratingApplication',
                 'source': 'windGeneratingApplication',
-                'units': '1',
                 'longName': 'Wind Generating Application',
             },
             {
@@ -101,16 +108,19 @@ class SatWndAmvObsBuilder(ObsBuilder):
 
     # Methods that are used to extend the obs data container
     def _add_wind_obs(self, container, cat):
-
         satId = container.get('satelliteId', cat)
         if not satId.size:
             self.log.warning(f'category {cat[0]} does not exist in input file')
-            add_dummy_variable(container, 'obstype_uwind', cat, 'windComputationMethod')
-            add_dummy_variable(container, 'obstype_vwind', cat, 'windComputationMethod')
-            add_dummy_variable(container, 'windEastward', cat, 'windSpeed')
-            add_dummy_variable(container, 'windNorthward', cat, 'windSpeed')
-            add_dummy_variable(container, 'height', cat, 'pressure')
-            add_dummy_variable(container, 'stationElevation', cat, 'pressure')
+
+            dummy_mappings = [
+                ('obstype_uwind', 'satelliteId'),
+                ('obstype_vwind', 'satelliteId'),
+                ('windEastward', 'windSpeed'),
+                ('windNorthward', 'windSpeed')
+            ]
+            for target_var, source_var in dummy_mappings:
+                add_dummy_variable(container, target_var, cat, source_var)
+
             return
 
         # Add new ObsType variables: ObsType/windEastward & ObsType/windNorthward
@@ -144,6 +154,20 @@ class SatWndAmvObsBuilder(ObsBuilder):
         container.add('windEastward', uob, paths, cat)
         container.add('windNorthward', vob, paths, cat)
 
+    def _add_metadata(self, container, cat):
+        satId = container.get('satelliteId', cat)
+        if not satId.size:
+            self.log.warning(f'category {cat[0]} does not exist in input file')
+
+            dummy_mappings = [
+                ('height', 'pressure'),
+                ('stationElevation', 'pressure')
+            ]
+            for target_var, source_var in dummy_mappings:
+                add_dummy_variable(container, target_var, cat, source_var)
+
+            return
+
         # Add new MetaData variables: MetaData/height & MetaData/stationElevation
         pressure = container.get("pressure", cat)
         height = np.full_like(pressure, fill_value=pressure.fill_value, dtype=np.float32)
@@ -160,8 +184,14 @@ class SatWndAmvObsBuilder(ObsBuilder):
         satId = container.get('satelliteId', cat)
 
         if not satId.size:
-            add_dummy_variable(container, 'windGeneratingApplication', cat, 'windComputationMethod')
-            add_dummy_variable(container, 'qualityInformationWithoutForecast', cat, 'windSpeed')
+
+            dummy_mappings = [
+                ('windGeneratingApplication', 'windComputationMethod'),
+                ('qualityInformationWithoutForecast', 'windSpeed')
+            ]
+            for target_var, source_var in dummy_mappings:
+                add_dummy_variable(container, target_var, cat, source_var)
+
             return
 
         gnap, qifn = self._get_quality_info_and_gen_app(findQi, gnap2D, pccf2D)

--- a/dump/mapping/bufr_satwnd_amv_seviri.py
+++ b/dump/mapping/bufr_satwnd_amv_seviri.py
@@ -4,8 +4,8 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import add_main_functions
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder, map_path
+from bufr.obs_builder import add_main_functions, map_path
+from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
 MAPPING_PATH = map_path('bufr_satwnd_amv_seviri.yaml')

--- a/dump/mapping/bufr_satwnd_amv_seviri.yaml
+++ b/dump/mapping/bufr_satwnd_amv_seviri.yaml
@@ -29,9 +29,11 @@ bufr:
 
     sensorCentralFrequency:
       query: "*/SCCF"
+      type: float
 
     pressure:
       query: "*/PRLC[1]"
+      type: float
 
     # Processing Center
     dataProviderOrigin:
@@ -44,6 +46,7 @@ bufr:
     # Quality Information Without Forecast
     qualityInformationWithoutForecast:
       query: '*/AMVQIC{2}/PCCF'
+      type: float
 
     # Wind Retrieval Method Information - Computation 
     windComputationMethod:
@@ -52,6 +55,7 @@ bufr:
     # ObsValue - Wind Direction
     windDirection:
       query: '*/WDIR'
+      type: float
 
     # ObsValue - Wind Speed
     windSpeed:
@@ -151,6 +155,7 @@ encoder:
     - name: "MetaData/qiWithoutForecast"
       source: variables/qualityInformationWithoutForecast
       longName: "Quality Information Without Forecast"
+      units: "percent"
 
     - name: "MetaData/pressure"
       source: variables/pressure

--- a/dump/mapping/bufr_satwnd_amv_seviri.yaml
+++ b/dump/mapping/bufr_satwnd_amv_seviri.yaml
@@ -73,25 +73,33 @@ bufr:
 
 encoder:
   globals:
+    - name: "description"
+      type: string
+      value: "Atmospheric Motion Vectors (AMVs) derived from MSG SEVIRI using three spectral bands: longwave IR (LWIR), water vapor/cloud top (WVCT) and visible"
+
     - name: "platformCommonName"
       type: string
-      value: "METEOSAT"
+      value: "Meteosat"
 
     - name: "platformLongDescription"
       type: string
-      value: "Geostationary Operational Satellite"
+      value: "Meteosat Second Generation (MSG)"
 
-    - name: "sensor"
+    - name: "sensorCommonName"
       type: string
-      value: "Spinning Enhanced Visible Infra-Red Imager"
+      value: "SEVIRI"
+
+    - name: "sensorLongDescription"
+      type: string
+      value: "Spinning Enhanced Visible Infra-Red Imager with 12 channels (11 narrow-bandwidth, 1 high-resolution broad-bandwidth VIS)"
 
     - name: "source"
       type: string
-      value: "NCEP BUFR Dump for satellite derived atmospheric motion vectors (satwnd)"
+      value: "U.S. National Weather Service, National Centres for Environmental Prediction (NCEP))"
 
-    - name: "providerFullName"
+    - name: "sourceFiles"
       type: string
-      value: "European Organisation for the Exploitation of Meteorological Satellites"
+      value: "NCEP BUFR Dump - satwnd: NC005067 (LWIR), NC005068(VIS), NC005069(WV/CT)"
 
     - name: "processingLevel"
       type: string
@@ -99,7 +107,7 @@ encoder:
 
     - name: "converter"
       type: string
-      value: "BUFR"
+      value: "bufr-query"
 
   variables:
 
@@ -156,7 +164,7 @@ encoder:
     - name: "MetaData/pressure"
       source: variables/pressure
       longName: "Pressure"
-      units: "pa"
+      units: "Pa"
 
     - name: "ObsValue/windDirection"
       source: variables/windDirection

--- a/dump/mapping/bufr_satwnd_amv_seviri.yaml
+++ b/dump/mapping/bufr_satwnd_amv_seviri.yaml
@@ -72,10 +72,6 @@ bufr:
           _70: m11  
 
 encoder:
-# type: netcdf
-
-# dimensions:
-
   globals:
     - name: "platformCommonName"
       type: string

--- a/dump/mapping/bufr_satwnd_amv_viirs.py
+++ b/dump/mapping/bufr_satwnd_amv_viirs.py
@@ -4,8 +4,8 @@ import os
 import numpy as np
 
 import bufr
-from bufr.obs_builder import add_main_functions
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder, map_path
+from bufr.obs_builder import add_main_functions, map_path
+from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
 MAPPING_PATH = map_path('bufr_satwnd_amv_viirs.yaml')

--- a/dump/mapping/bufr_satwnd_amv_viirs.yaml
+++ b/dump/mapping/bufr_satwnd_amv_viirs.yaml
@@ -69,10 +69,6 @@ bufr:
           _226: n21
 
 encoder:
-# type: netcdf
-
-# dimensions:
-
   globals:
     - name: "platformCommonName"
       type: string

--- a/dump/mapping/bufr_satwnd_amv_viirs.yaml
+++ b/dump/mapping/bufr_satwnd_amv_viirs.yaml
@@ -27,9 +27,11 @@ bufr:
 
     sensorCentralFrequency:
       query: "*/SCCF"
+      type: float
 
     pressure:
       query: "*/PRLC[1]"
+      type: float
 
     # Processing Center
     dataProviderOrigin:
@@ -42,6 +44,7 @@ bufr:
     # Quality Information - contains multiple types
     qualityInformation:
       query: '*/AMVQIC/PCCF'
+      type: float
 
     # Wind Retrieval Method Information - Computation 
     windComputationMethod:
@@ -50,6 +53,7 @@ bufr:
     # ObsValue - Wind Direction
     windDirection:
       query: '*/WDIR'
+      type: float
 
     # ObsValue - Wind Speed
     windSpeed:

--- a/dump/mapping/bufr_satwnd_amv_viirs.yaml
+++ b/dump/mapping/bufr_satwnd_amv_viirs.yaml
@@ -70,6 +70,10 @@ bufr:
 
 encoder:
   globals:
+    - name: "description"
+      type: string
+      value: "Atmospheric Motion Vectors (AMVs) derived from VIIRS using longwave IR (LWIR) spectral band"
+
     - name: "platformCommonName"
       type: string
       value: "SUOMI-NPP/NOAA-20/NOAA-21"
@@ -78,17 +82,21 @@ encoder:
       type: string
       value: "Low-Earth Orbiting Operational Satellite"
 
-    - name: "sensor"
+    - name: "sensorCommonName"
       type: string
-      value: "Visible Infrared Imaging Radiometer Suite"
+      value: "VIIRS"
+
+    - name: "sensorLongDescription"
+      type: string
+      value: "Visible Infrared Imaging Radiometer Suite wit 22 channels, including a day/night 0.7 µm channel; cross-scanning"
 
     - name: "source"
       type: string
-      value: "NCEP BUFR Dump for satellite derived atmospheric motion vectors (satwnd)"
+      value: "U.S. National Weather Service, National Centres for Environmental Prediction (NCEP))"
 
-    - name: "providerFullName"
+    - name: "sourceFiles"
       type: string
-      value: "National Environmental Satellite, Data, and Information Service"
+      value: "NCEP BUFR Dump - satwnd NC005091"
 
     - name: "processingLevel"
       type: string
@@ -96,7 +104,7 @@ encoder:
 
     - name: "converter"
       type: string
-      value: "BUFR"
+      value: "bufr-query"
 
   variables:
 
@@ -144,7 +152,7 @@ encoder:
     - name: "MetaData/pressure"
       source: variables/pressure
       longName: "Pressure"
-      units: "pa"
+      units: "Pa"
 
     - name: "ObsValue/windDirection"
       source: variables/windDirection


### PR DESCRIPTION
### *This PR modified the satellite AMV converters to use the following:
- Use `compute_wind_components` from `bufr.transforms` import
- Use `map_path` from `bufr.obs_builder` import
- Use `add_dummy_variable` from `bufr.obs_builder (see [bufr-query PR #76](https://github.com/NOAA-EMC/bufr-query/pull/76#event-17692612933))
- Add MetaData variables: height and stationElevation to all satellite wind types (abi, ahi, etc).   So, this is implemented in `bufr_satwnd_amv_obs_builder.py`.  These two MetaData do not exist in the satwnd BUFR, but they are needed for the satwind observation operator in UFO. 

In the future, we do not need to include these two MetaData (height and station elevation) in the pre-processing. They can be created in UFO via a variable assignment filter. These two variables are needed for all satellite wind types, so they are added in the `SatWndAmvObsBuilder` class.

### A few fixes
**1. Data Type** - The following variables need data type conversion from integer to float to meet [IODA convention requirement](https://docs.google.com/spreadsheets/d/e/2PACX-1vRvM7vLTsUZs-xJZHha1vZDQZyFSrybKfNvN9lIFJY6yB2MQDmBH_MofWha2R7uhPl6frKKbGDQmd0g/pubhtml)
- pressure
- sensorCentralFrequency
- qiWithouthForecast
- expectedError
- windDirection

**2.  Unit** - The unit of `qiWithoutForecast` (quality information) should be `percent`  
     (bufr_satwnd_amv_obsBuilder.sh, bufr_satwnd_amv_abi.yamo. bufr_satwnd_amv_leogeo.yaml, bufr_satwnd_amv_seviri.yaml)

**3. Quality Information** - pass incorrect quality information due to memory issue.  Need to copy the sliced data to a new variable, remove squeeze(), and do not assign type to int32 to gnap and qifn (the data type will be determined by path later when encoding)

 In _get_quality_info_and_gen_app(self, findQi, gnap2D, pccf2D)
 Change the following 
         
```
        for i in range(gDim2):
            if np.unique(gnap2D[:, i].squeeze()) == findQi:
                if i <= qDim2:
                    self.log.info(f'GNAP/PCCF found for column {i}')
                    gnap = gnap2D[:, i].squeeze()
                    qifn = pccf2D[:, i].squeeze()
                else:
                    self.log.info(f'ERROR: GNAP column {i} outside of PCCF dimension {qDim2}')
        if (gnap is None) & (qifn is None):
            raise ValueError(f'GNAP == {findQi} NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
        # If EE is needed, key search on np.unique(gnap2D[:,i].squeeze()) == 7 instead
        # NOTE: Make sure to return np.float32 or np.int32 types as appropriate!!!
        return gnap.astype(np.int32), qifn.astype(np.int32)
 ```
 to
 ```
        for i in range(gDim2):
            print('emily checking i = ', i)
            if np.all(np.unique(gnap2D[:, i]) == findQi):
                if i < qDim2:
                    self.log.info(f'GNAP/PCCF found for column {i}')
                    gnap = gnap2D[:, i].copy()
                    qifn = pccf2D[:, i].copy()
                else:
                    self.log.info(f'ERROR: GNAP column {i} outside of PCCF dimension {qDim2}')

        if (gnap is None) & (qifn is None):
            raise ValueError(f'GNAP == {findQi} NOT FOUND OR OUT OF PCCF DIMENSION-RANGE, WILL FAIL!')
        # If EE is needed, key search on np.unique(gnap2D[:,i].squeeze()) == 7 instead
        return gnap, qifn
 ```

**4. Query string issue in LEOGEO YAML** - the query string is wrong for `qualityInformation

Here is the bufr table for LEOGEO (NC005072)
```
| NC005072 | GEOSTWND  "LGRSQ3"103  GCLONG  GNAP  "LGRSQ4"10  GCLONG  GNAP     |
| NC005072 | "LGRSQ4"10  GCLONG  GNAP  "LGRSQ4"10                              |
```
The LGRSQ4 replicating 10 times, and we want to grab the first one.  
The following query will get 2D array out [Location, 10]. This is not what we want.  
```
    # Quality Information Without Forecast
    qualityInformationWithoutForecast:
      query: '*/LGRSQ4[1]/PCCF'
```

2D array [Location, 10]
```
   qiWithoutForecast =
  76, 76, 0, 0, 0, 0, 0, 0, 0, 0,
  67, 67, 0, 0, 0, 0, 0, 0, 0, 0,
  63, 63, 0, 0, 0, 0, 0, 0, 0, 0,
  63, 63, 0, 0, 0, 0, 0, 0, 0, 0,
  86, 86, 0, 0, 0, 0, 0, 0, 0, 0,
  64, 64, 0, 0, 0, 0, 0, 0, 0, 0,
                 : 
                 :

```


We want to extract the first one [Location, 1].  So, the query string should be:
```
    # Quality Information Without Forecast
    qualityInformationWithoutForecast:
      query: '*/LGRSQ4[1]{1}/PCCF'
      type: float
```
1-D array [Location]
``` 
   Without Forecast = 76, 67, 63, 63, 86, 64, 60, 74, 89, 71, 63, 70, 87,
      88, 75, 66, 80, 83, 64, 71, 84, 88, 71, 82, 54, 69, 72, 86, 70, 66, 88,
      66, 64, 66, 90, 81, 65, 84, 63, 59, 67, 63, 73, 70, 72, 69, 72, 93, 81,
      86, 66, 54, 61, 63, 94, 64, 63, 56, 74, 66, 57, 75, 67, 69, 99, 98, 97,
      100, 81, 89, 90, 58, 73, 97, 64, 94, 62, 66, 57, 70, 89, 85, 87, 83,
      85, 78, 78, 78, 85, 74, 90, 74, 70, 79, 79, 57, 100, 63, 66, 78, 77,
      83, 95, 82, 88, 66, 87, 64, 65, 74, 65, 59, 67, 86, 63, 63, 69, 65, 81,
      86, 76, 64, 99, 81, 76, 56, 83, 88, 79, 62, 70, 83, 86, 64, 60, 74, 70,
      87, 80, 74, 63, 95, 91, 96, 89, 61, 67, 60, 71, 77, 67, 69, 57, 74, 67,
                   :
                   :
```

Notes:
Sensors use quality information directly from mapping YAML - abi, leogeo, seviri
Sensors need to processing additional information to get quality information - ahi, avhrr, viirs, modis

    

