### PR TITLE
Add GMI mapping yaml file

### DIFF
--- a/dump/mapping/bufr_gmi.yaml
+++ b/dump/mapping/bufr_gmi.yaml
@@ -11,10 +11,10 @@ bufr:
         second: "*/SECO"
 
     latitude:
-      query: "*/CLATH"
+      query: "*/PIXELS{1}/CLATH"
 
     longitude:
-      query: "*/CLONH"
+      query: "*/PIXELS{1}/CLONH"
 
     satelliteId:
       query: "*/SAID"
@@ -23,31 +23,33 @@ bufr:
       query: "*/SLNM"
 
     fieldOfViewNumber:
-      query: "*/FOVN"
+      query: "*/PIXELS{1}/FOVN"
 
     sensorChannelNumber:
-      query: "*/CHNM"
-
-#    brightnessTemperature:
-#      query: "*/SSMISCHN/TMBR"
+      query: "*/PIXELS{1}/GMICHT/CHNM"
 
     sensorScanAngle:
       sensorScanAngle:
-        fieldOfViewNumber: "*/FOVN"
+        fieldOfViewNumber: "*/PIXELS{1}/FOVN"
         scanStart: 0.0 
         scanStep: 0.0 
         sensor: gmi
 
+    BrightnessTemperature:
+      query: "*/PIXELS{1}/GMICHT/TMBR"
+
+
     remappedBT:
       remappedBrightnessTemperature:
         sensor: gmi
-        method: 1
+        method: 2
         satelliteId: "*/SAID"
-        latitude: "*/CLATH"
-        longitude: "*/CLONH"
-        fieldOfViewNumber: "*/FOVN"
-        sensorChannelNumber: "*/CHNM"
-        brightnessTemperature: "*/TMBR"
+        latitude: "*/PIXELS{1}/CLATH"
+        longitude: "*/PIXELS{1}/CLONH"
+        fieldOfViewNumber: "*/PIXELS{1}/FOVN"
+        rainFlag: "*/PIXELS{1}/GMICHT"
+        sensorChannelNumber: "*/PIXELS{1}/GMICHT/CHNM"
+        brightnessTemperature: "*/PIXELS{1}/GMICHT/TMBR"
         obsTime:
           year: "*/YEAR"
           month: "*/MNTH"
@@ -55,21 +57,14 @@ bufr:
           hour: "*/HOUR"
           minute: "*/MINU"
           second: "*/SECO"
+        
+
 
 encoder:
   dimensions:
     - name: Channel
-      source: variables/sensorChannelNumber  
-  
-  globals:
-    - name: "platformCommonName"
-      type: string
-      value: "SSMIS-DMSP18"
-  
-    - name: "platformLongDescription"
-      type: string
-      value: "MTYP 021-201 DMSP SSM/IS Tb (UNIFIED PRE-PROCESSOR)"
-  
+      #source: variables/sensorChannelNumber
+      path: "*/PIXELS{1}/GMICHT"
   globals:
     - name: "platformCommonName"
       type: string
@@ -138,20 +133,22 @@ encoder:
       source: variables/scanLineNumber
       longName: "Scan Line Number"
   
-#    # ObsValue
-#    # Brightness Temperature
-#    - name: "ObsValue/brightnessTemperature"
-#      source: variables/brightnessTemperature
-#      longName: "Brightness Temperature"
-#      units: "K"
-#      range: [120, 500]
-#      chunks: [10000, 24]
-
-    # ObsValue
+        #   # ObsValue
+        #   # Brightness Temperature
+        #    - name: "ObsValue/brightnessTemperature"
+        #      source: variables/BrightnessTemperature
+        #      longName: "Brightness Temperature"
+        #      units: "K"
+        #      range: [120, 500]
+        # chunks: [10000, 24]
+        #
+        #
+# ObsValue
     # Remapped Brightness Temperature
     - name: "ObsValue/brightnessTemperature"
       source: variables/remappedBT
       longName: "3-by-3 Averaged Brightness Temperature"
       units: "K"
       range: [120, 500]
-      chunks: [10000, 24]
+        #      chunks: [10000, 24]
+

--- a/dump/mapping/bufr_gmi.yaml
+++ b/dump/mapping/bufr_gmi.yaml
@@ -38,7 +38,6 @@ bufr:
     BrightnessTemperature:
       query: "*/PIXELS{1}/GMICHT/TMBR"
 
-
     remappedBT:
       remappedBrightnessTemperature:
         sensor: gmi
@@ -58,8 +57,6 @@ bufr:
           minute: "*/MINU"
           second: "*/SECO"
         
-
-
 encoder:
   dimensions:
     - name: Channel
@@ -133,16 +130,6 @@ encoder:
       source: variables/scanLineNumber
       longName: "Scan Line Number"
   
-        #   # ObsValue
-        #   # Brightness Temperature
-        #    - name: "ObsValue/brightnessTemperature"
-        #      source: variables/BrightnessTemperature
-        #      longName: "Brightness Temperature"
-        #      units: "K"
-        #      range: [120, 500]
-        # chunks: [10000, 24]
-        #
-        #
 # ObsValue
     # Remapped Brightness Temperature
     - name: "ObsValue/brightnessTemperature"
@@ -150,5 +137,3 @@ encoder:
       longName: "3-by-3 Averaged Brightness Temperature"
       units: "K"
       range: [120, 500]
-        #      chunks: [10000, 24]
-

--- a/dump/mapping/bufr_gmi.yaml
+++ b/dump/mapping/bufr_gmi.yaml
@@ -65,19 +65,19 @@ encoder:
   globals:
     - name: "platformCommonName"
       type: string
-      value: "JPSS"
+      value: "GPM"
 
     - name: "platformLongDescription"
       type: string
-      value: "Joint Polar Satellite System"
+      value: "NASA Core Observatory satellite"
 
     - name: "sensor"
       type: string
-      value: "Special Sensor Microwave Imager / Sounder (SSMIS)"
+      value: "GMI"
 
     - name: "source"
       type: string
-      value: "NCEP BUFR Dump for SSMIS brightness temperature data (ssmisu)"
+      value: "NCEP BUFR Dump for GMI brightness temperature data"
 
     - name: "providerFullName"
       type: string
@@ -85,7 +85,7 @@ encoder:
 
     - name: "processingLevel"
       type: string
-      value: "Level-1B"
+      value: "Level-1CR"
 
     - name: "converter"
       type: string

--- a/dump/mapping/bufr_gmi.yaml
+++ b/dump/mapping/bufr_gmi.yaml
@@ -25,6 +25,21 @@ bufr:
     fieldOfViewNumber:
       query: "*/PIXELS{1}/FOVN"
 
+    satelliteZenithAngle:
+      query: "*/PIXELS{1}/GMIANG/SAZA"
+
+    bearingOrAzimuth:
+      query: "*/PIXELS{1}/GMIANG/BEARAZ"
+
+    solarZenithAngle:
+      query: "*/PIXELS{1}/GMIANG/SOZA"
+
+    solarAzimuth:
+      query: "*/PIXELS{1}/GMIANG/SOLAZI"
+
+    satelliteSunGlintAngle:
+      query: "*/PIXELS{1}/GMIANG/SSGA"
+
     sensorChannelNumber:
       query: "*/PIXELS{1}/GMICHT/CHNM"
 
@@ -125,7 +140,32 @@ encoder:
       source: variables/sensorScanAngle
       longName: "Sensor View Angle"
       units: "degree"
-  
+ 
+    - name: "MetaData/satelliteZenithAngle"
+      source: "variables/satelliteZenithAngle"
+      longName: "Satellite Zenith Angle"
+      units: "degree"
+
+    - name: "MetaData/bearingOrAzimuth"
+      source: "variables/bearingOrAzimuth"
+      longName: "Bearing or Azimuth"
+      units: "degree"
+
+    - name: "MetaData/solarZenithAngle"
+      source: "variables/solarZenithAngle"
+      longName: "Solar Zenith Angle"
+      units: "degree"
+
+    - name: "MetaData/solarAzimuth"
+      source: "variables/solarAzimuth"
+      longName: "Solar Azimuth"
+      units: "degree"
+
+    - name: "MetaData/satelliteSunGlintAngle"
+      source: "variables/satelliteSunGlintAngle"
+      longName: "Satellite-Sun Glint Angle"
+      units: "degree"
+
     - name: "MetaData/scanLineNumber"
       source: variables/scanLineNumber
       longName: "Scan Line Number"

--- a/dump/mapping/bufr_gmi_mapping.yaml
+++ b/dump/mapping/bufr_gmi_mapping.yaml
@@ -1,0 +1,157 @@
+bufr:
+  variables:
+    # MetaData
+    timestamp:
+      datetime:
+        year: "*/YEAR"
+        month: "*/MNTH"
+        day: "*/DAYS"
+        hour: "*/HOUR"
+        minute: "*/MINU"
+        second: "*/SECO"
+
+    latitude:
+      query: "*/CLATH"
+
+    longitude:
+      query: "*/CLONH"
+
+    satelliteId:
+      query: "*/SAID"
+
+    scanLineNumber:
+      query: "*/SLNM"
+
+    fieldOfViewNumber:
+      query: "*/FOVN"
+
+    sensorChannelNumber:
+      query: "*/CHNM"
+
+#    brightnessTemperature:
+#      query: "*/SSMISCHN/TMBR"
+
+    sensorScanAngle:
+      sensorScanAngle:
+        fieldOfViewNumber: "*/FOVN"
+        scanStart: 0.0 
+        scanStep: 0.0 
+        sensor: gmi
+
+    remappedBT:
+      remappedBrightnessTemperature:
+        sensor: gmi
+        method: 1
+        satelliteId: "*/SAID"
+        latitude: "*/CLATH"
+        longitude: "*/CLONH"
+        fieldOfViewNumber: "*/FOVN"
+        sensorChannelNumber: "*/CHNM"
+        brightnessTemperature: "*/TMBR"
+        obsTime:
+          year: "*/YEAR"
+          month: "*/MNTH"
+          day: "*/DAYS"
+          hour: "*/HOUR"
+          minute: "*/MINU"
+          second: "*/SECO"
+
+encoder:
+  dimensions:
+    - name: Channel
+      source: variables/sensorChannelNumber  
+  
+  globals:
+    - name: "platformCommonName"
+      type: string
+      value: "SSMIS-DMSP18"
+  
+    - name: "platformLongDescription"
+      type: string
+      value: "MTYP 021-201 DMSP SSM/IS Tb (UNIFIED PRE-PROCESSOR)"
+  
+  globals:
+    - name: "platformCommonName"
+      type: string
+      value: "JPSS"
+
+    - name: "platformLongDescription"
+      type: string
+      value: "Joint Polar Satellite System"
+
+    - name: "sensor"
+      type: string
+      value: "Special Sensor Microwave Imager / Sounder (SSMIS)"
+
+    - name: "source"
+      type: string
+      value: "NCEP BUFR Dump for SSMIS brightness temperature data (ssmisu)"
+
+    - name: "providerFullName"
+      type: string
+      value: "National Environmental Satellite, Data, and Information Service"
+
+    - name: "processingLevel"
+      type: string
+      value: "Level-1B"
+
+    - name: "converter"
+      type: string
+      value: "BUFR"
+
+  variables:
+    # MetaData
+    - name: "MetaData/dateTime"
+      source: variables/timestamp
+      longName: "Datetime"
+      units: "seconds since 1970-01-01T00:00:00Z" 
+  
+    - name: "MetaData/latitude"
+      source: variables/latitude
+      longName: "Latitude"
+      units: "degree_north"
+      range: [-90, 90]
+  
+    - name: "MetaData/longitude"
+      source: variables/longitude
+      longName: "Longitude"
+      units: "degree_east"
+  
+    - name: "MetaData/satelliteIdentifier"
+      source: variables/satelliteId
+      longName: "Satellite Identifier"
+  
+    - name: "MetaData/sensorScanPosition"
+      source: variables/fieldOfViewNumber
+      longName: "Field of View Number"
+  
+    - name: "MetaData/sensorChannelNumber"
+      source: variables/sensorChannelNumber
+      longName: "Sensor Channel Number"
+  
+    - name: "MetaData/sensorViewAngle"
+      source: variables/sensorScanAngle
+      longName: "Sensor View Angle"
+      units: "degree"
+  
+    - name: "MetaData/scanLineNumber"
+      source: variables/scanLineNumber
+      longName: "Scan Line Number"
+  
+#    # ObsValue
+#    # Brightness Temperature
+#    - name: "ObsValue/brightnessTemperature"
+#      source: variables/brightnessTemperature
+#      longName: "Brightness Temperature"
+#      units: "K"
+#      range: [120, 500]
+#      chunks: [10000, 24]
+
+    # ObsValue
+    # Remapped Brightness Temperature
+    - name: "ObsValue/brightnessTemperature"
+      source: variables/remappedBT
+      longName: "3-by-3 Averaged Brightness Temperature"
+      units: "K"
+      range: [120, 500]
+      chunks: [10000, 24]


### PR DESCRIPTION
A GMI YAML file was created to convert the BUFR file into IODA format, applying spatial averaging for thinning.

For validation of the results, please refer to the following link: https://github.com/NOAA-EMC/spoc/issues/53