### PR TITLE
remove bufr_ inside .py

### DIFF
--- a/dump/scripts/atmosphere/amsua.py
+++ b/dump/scripts/atmosphere/amsua.py
@@ -2,11 +2,11 @@
 import os
 from bufr.obs_builder import add_main_functions, map_path
 
-from bufr_atovs_obs_builder import AtovsObsBuilder, NMFD, RARS
+from atovs_obs_builder import AtovsObsBuilder, NMFD, RARS
 
 
-NMFD_MAPPING = map_path('bufr_amsua_1bamua.yaml')
-RARS_MAPPING = map_path('bufr_amsua_esamua.yaml')
+NMFD_MAPPING = map_path('amsua_1bamua.yaml')
+RARS_MAPPING = map_path('amsua_esamua.yaml')
 
 
 class AmsuaObsBuilder(AtovsObsBuilder):

--- a/dump/scripts/atmosphere/atms.py
+++ b/dump/scripts/atmosphere/atms.py
@@ -7,7 +7,7 @@ import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions, map_path
 
 
-MAPPING_PATH = map_path('bufr_atms.yaml')
+MAPPING_PATH = map_path('atms.yaml')
 
 
 class BufrAtmsObsBuilder(ObsBuilder):

--- a/dump/scripts/atmosphere/atovs_obs_builder.py
+++ b/dump/scripts/atmosphere/atovs_obs_builder.py
@@ -18,8 +18,8 @@ COSMIC_BACKGROUND_TEMP = 2.7253
 nc_dir = './aux'
 
 
-NMFD_MAPPING = map_path('bufr_amsua_1bamua.yaml')
-RARS_MAPPING = map_path('bufr_amsua_esamua.yaml')
+NMFD_MAPPING = map_path('amsua_1bamua.yaml')
+RARS_MAPPING = map_path('amsua_esamua.yaml')
 
 
 class ACCoeff:

--- a/dump/scripts/atmosphere/avhrr.py
+++ b/dump/scripts/atmosphere/avhrr.py
@@ -5,7 +5,7 @@ import numpy as np
 import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions, map_path
 
-MAPPING_PATH = map_path('bufr_avhrr.yaml')
+MAPPING_PATH = map_path('avhrr.yaml')
 
 
 class BufrGsrasrObsBuilder(ObsBuilder):

--- a/dump/scripts/atmosphere/cris-fsr.py
+++ b/dump/scripts/atmosphere/cris-fsr.py
@@ -7,7 +7,7 @@ import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions, map_path
 
 
-MAPPING_PATH = map_path('bufr_cris-fsr.yaml')
+MAPPING_PATH = map_path('cris-fsr.yaml')
 
 
 class BufrCrisObsBuilder(ObsBuilder):

--- a/dump/scripts/atmosphere/iasi.py
+++ b/dump/scripts/atmosphere/iasi.py
@@ -7,7 +7,7 @@ import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions, map_path
 
 
-MAPPING_PATH = map_path('bufr_iasi.yaml')
+MAPPING_PATH = map_path('iasi.yaml')
 
 
 class BufrIasiObsBuilder(ObsBuilder):

--- a/dump/scripts/atmosphere/mhs.py
+++ b/dump/scripts/atmosphere/mhs.py
@@ -2,11 +2,11 @@
 import os
 from bufr.obs_builder import add_main_functions, map_path
 
-from bufr_atovs_obs_builder import AtovsObsBuilder, NMFD, RARS
+from atovs_obs_builder import AtovsObsBuilder, NMFD, RARS
 
 
-NMFD_MAPPING = map_path('bufr_mhs_1bmhs.yaml')
-RARS_MAPPING = map_path('bufr_mhs_esmhs.yaml')
+NMFD_MAPPING = map_path('mhs_1bmhs.yaml')
+RARS_MAPPING = map_path('mhs_esmhs.yaml')
 
 
 class MhsObsBuilder(AtovsObsBuilder):

--- a/dump/scripts/atmosphere/ozone_omi.py
+++ b/dump/scripts/atmosphere/ozone_omi.py
@@ -5,9 +5,9 @@ import numpy.ma as ma
 
 import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions, map_path
-from bufr_ozone_obs_builder import BufrOzoneObsBuilder
+from ozone_obs_builder import BufrOzoneObsBuilder
 
-MAPPING_PATH = map_path('bufr_ozone_omi.yaml')
+MAPPING_PATH = map_path('ozone_omi.yaml')
 
 
 class BufrOzoneOmiObsBuilder(BufrOzoneObsBuilder):

--- a/dump/scripts/atmosphere/ozone_ompsnp.py
+++ b/dump/scripts/atmosphere/ozone_ompsnp.py
@@ -6,9 +6,9 @@ import numpy.ma as ma
 import bufr
 from bufr.bufr_python.encoders import netcdf
 from bufr.obs_builder import ObsBuilder, add_main_functions, add_dummy_variable, map_path
-from bufr_ozone_obs_builder import BufrOzoneObsBuilder
+from ozone_obs_builder import BufrOzoneObsBuilder
 
-MAPPING_PATH = map_path('bufr_ozone_ompsnp.yaml')
+MAPPING_PATH = map_path('ozone_ompsnp.yaml')
 USE_REFERENCE_PRESSURE = True
 
 

--- a/dump/scripts/atmosphere/ozone_ompstc.py
+++ b/dump/scripts/atmosphere/ozone_ompstc.py
@@ -5,9 +5,9 @@ import numpy.ma as ma
 
 import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions, map_path
-from bufr_ozone_obs_builder import BufrOzoneObsBuilder
+from ozone_obs_builder import BufrOzoneObsBuilder
 
-MAPPING_PATH = map_path('bufr_ozone_ompstc.yaml')
+MAPPING_PATH = map_path('ozone_ompstc.yaml')
 
 
 class BufrOzoneOmpstcObsBuilder(BufrOzoneObsBuilder):

--- a/dump/scripts/atmosphere/satwnd_amv_abi.py
+++ b/dump/scripts/atmosphere/satwnd_amv_abi.py
@@ -5,10 +5,10 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import add_main_functions, map_path
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
+from satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
-MAPPING_PATH = map_path('bufr_satwnd_amv_abi.yaml')
+MAPPING_PATH = map_path('satwnd_amv_abi.yaml')
 
 
 class SatWndAmvAbiObsBuilder(SatWndAmvObsBuilder):

--- a/dump/scripts/atmosphere/satwnd_amv_ahi.py
+++ b/dump/scripts/atmosphere/satwnd_amv_ahi.py
@@ -5,10 +5,10 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import add_main_functions, map_path
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
+from satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
-MAPPING_PATH = map_path('bufr_satwnd_amv_ahi.yaml')
+MAPPING_PATH = map_path('satwnd_amv_ahi.yaml')
 FIND_QI = 102
 
 

--- a/dump/scripts/atmosphere/satwnd_amv_avhrr.py
+++ b/dump/scripts/atmosphere/satwnd_amv_avhrr.py
@@ -5,10 +5,10 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import add_main_functions, map_path, add_dummy_variable
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
+from satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
-MAPPING_PATH = map_path('bufr_satwnd_amv_avhrr.yaml')
+MAPPING_PATH = map_path('satwnd_amv_avhrr.yaml')
 
 
 class SatWndAmvAvhrrObsBuilder(SatWndAmvObsBuilder):

--- a/dump/scripts/atmosphere/satwnd_amv_leogeo.py
+++ b/dump/scripts/atmosphere/satwnd_amv_leogeo.py
@@ -5,10 +5,10 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import add_main_functions, map_path
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
+from satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
-MAPPING_PATH = map_path('bufr_satwnd_amv_leogeo.yaml')
+MAPPING_PATH = map_path('satwnd_amv_leogeo.yaml')
 
 
 class SatWndAmvLeogeoObsBuilder(SatWndAmvObsBuilder):

--- a/dump/scripts/atmosphere/satwnd_amv_modis.py
+++ b/dump/scripts/atmosphere/satwnd_amv_modis.py
@@ -5,10 +5,10 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import add_main_functions, map_path
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
+from satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
-MAPPING_PATH = map_path('bufr_satwnd_amv_modis.yaml')
+MAPPING_PATH = map_path('satwnd_amv_modis.yaml')
 FIND_QI = 1
 
 

--- a/dump/scripts/atmosphere/satwnd_amv_seviri.py
+++ b/dump/scripts/atmosphere/satwnd_amv_seviri.py
@@ -5,10 +5,10 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import add_main_functions, map_path
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
+from satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
-MAPPING_PATH = map_path('bufr_satwnd_amv_seviri.yaml')
+MAPPING_PATH = map_path('satwnd_amv_seviri.yaml')
 
 
 class SatWndAmvSeviriObsBuilder(SatWndAmvObsBuilder):

--- a/dump/scripts/atmosphere/satwnd_amv_viirs.py
+++ b/dump/scripts/atmosphere/satwnd_amv_viirs.py
@@ -5,10 +5,10 @@ import numpy as np
 
 import bufr
 from bufr.obs_builder import add_main_functions, map_path
-from bufr_satwnd_amv_obs_builder import SatWndAmvObsBuilder
+from satwnd_amv_obs_builder import SatWndAmvObsBuilder
 
 
-MAPPING_PATH = map_path('bufr_satwnd_amv_viirs.yaml')
+MAPPING_PATH = map_path('satwnd_amv_viirs.yaml')
 FIND_QI = 5
 
 

--- a/dump/scripts/atmosphere/scatwnd_ascat.py
+++ b/dump/scripts/atmosphere/scatwnd_ascat.py
@@ -8,7 +8,7 @@ from bufr.obs_builder import ObsBuilder, add_main_functions, map_path, add_dummy
 from bufr.transforms import compute_wind_components
 
 
-MAPPING_PATH = map_path('bufr_scatwnd_ascat.yaml')
+MAPPING_PATH = map_path('scatwnd_ascat.yaml')
 
 
 class BufrAscatObsBuilder(ObsBuilder):

--- a/dump/scripts/atmosphere/sfcsno.py
+++ b/dump/scripts/atmosphere/sfcsno.py
@@ -7,7 +7,7 @@ import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions
 
 
-MAPPING_PATH = map_path('bufr_sfcsno.yaml')
+MAPPING_PATH = map_path('sfcsno.yaml')
 
 
 class BufrSfcsnoObsBuilder(ObsBuilder):

--- a/dump/scripts/atmosphere/ssmis.py
+++ b/dump/scripts/atmosphere/ssmis.py
@@ -9,7 +9,7 @@ from bufr.obs_builder import nprocs_per_task, add_dummy_variable
 from bufr.transforms import compute_solar_angles
 from datetime import datetime
 
-MAPPING_PATH = map_path('bufr_ssmis.yaml')
+MAPPING_PATH = map_path('ssmis.yaml')
 
 
 class BufrSsmisObsBuilder(ObsBuilder):


### PR DESCRIPTION
In this PR (https://github.com/NOAA-EMC/spoc/pull/77), we standardized the file naming convention by removing the bufr_ prefix from both .py and .yaml files. The corresponding references inside the .py files also need to be updated to reflect this change.