### PR TITLE
Fix filled value for dateTime variable

### DIFF
--- a/dump/scripts/atmosphere/prepbufr_obs_builder.py
+++ b/dump/scripts/atmosphere/prepbufr_obs_builder.py
@@ -81,8 +81,13 @@ class PrepbufrObsBuilder(ObsBuilder):
     def _replace_timestamp(self, container: bufr.DataContainer, reference_time: np.datetime64) -> np.array:
         times = container.get('obsTimeMinusCycleTime')
 
-        cycle_times = ma.masked_array(np.round(3600 * times).astype(np.int), dtype='timedelta64[s]', mask=times.mask)
-        timestamps = ma.masked_array(reference_time + cycle_times,
-                                     mask=times.mask, dtype='datetime64[s]').astype('int64')
+        cycle_times = ma.masked_array(np.round(3600 * times).astype(np.int64),
+                                      dtype='timedelta64[s]',
+                                      mask=times.mask)
 
-        container.replace('timestamp', timestamps.filled())
+        timestamps = ma.masked_array(reference_time + cycle_times,
+                                     mask=times.mask,
+                                     fill_value=bufr.get_missing_value(np.int64),
+                                     dtype='datetime64[s]').astype('int64')
+
+        container.replace('timestamp', timestamps)


### PR DESCRIPTION
This PR fixes two bugs in the function of  _replace_timestamp 
1. Filled value for dateTime computed from reference time + time difference from analysis time does not have the correct type. 
2. Replace `np.int` with `np.int64` 

Resolve SPOC [Issue #80](https://github.com/NOAA-EMC/spoc/issues/80) 