### PR TITLE
obssubtype changes

### DIFF
--- a/dump/config/atmosphere/prepbufr_adpupa.yaml
+++ b/dump/config/atmosphere/prepbufr_adpupa.yaml
@@ -12,6 +12,8 @@ bufr:
     # ObsType
     observationType:
       query: "*/TYP"
+    observationSubType:
+      query: "*/T29"
 
     # MetaData
     timestamp:

--- a/dump/scripts/atmosphere/prepbufr_adpsfc.py
+++ b/dump/scripts/atmosphere/prepbufr_adpsfc.py
@@ -24,8 +24,39 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
                 'name': 'MetaData/sequenceNumber',
                 'source': 'sequenceNumber',
                 'longName': 'Sequence Number (Obs Subtype)',
+            },
+            {
+                'name': 'ObsSubType/stationPressure',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/airTemperature',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/virtualTemperature',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/specificHumidity',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/windEastward',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/windNorthward',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
             }
         ])
+
         return description
 
     def make_obs(self, comm, input_path):
@@ -33,6 +64,7 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
         Create the ioda adpsfc prepbufr observations:
         - reads values
         - adds sequenceNum
+        - adds ObsSubType
 
         Parameters
         ----------
@@ -56,9 +88,9 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
         dhr2 = np.array(dhr)
         self._replace_timestamp(container, self._get_reference_time(input_path))
 
-        self.log.debug(f'Make an array of 0s for MetaData/sequenceNumber')
+        self.log.debug(f'Make an array of 0s for MetaData/sequenceNumber and ObsSubType')
         sequenceNum = np.zeros(dhr.shape, dtype=np.int32)
-        self.log.debug(f' sequenceNummin/max =  {sequenceNum.min()} {sequenceNum.max()}')
+        self.log.debug(f' sequenceNum min/max =  {sequenceNum.min()} {sequenceNum.max()}')
 
         self.log.debug(f'Do tsen and tv calculation')
         tpc = container.get('temperatureEventCode')
@@ -93,6 +125,7 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
 
         self.log.debug(f'Add variables to container')
         container.add('sequenceNumber', sequenceNum, dhr_paths)
+        container.add('obsSubType', sequenceNum, dhr_paths)
 
         # Check
         self.log.debug(f'container list (updated): {container.list()}')

--- a/dump/scripts/atmosphere/prepbufr_adpupa.py
+++ b/dump/scripts/atmosphere/prepbufr_adpupa.py
@@ -42,6 +42,10 @@ class AdpupaPrepbufrObsBuilder(PrepbufrObsBuilder):
         hrdr = container.get('obsTimeMinusCycleTime')
         self._replace_timestamp(container, self._get_reference_time(input_path))
 
+        self.log.debug(f'Make an array of 0s for ObsSubType')
+        obsSubType = np.zeros(hrdr.shape, dtype=np.int32)
+        self.log.debug(f' obsSubType min/max =  {obsSubType.min()} {obsSubType.max()}')
+
         self.log.debug(f'Perform stationPressure, stationPressureQM, and stationPressureError calculations')
         cat = container.get('prepbufrDataLevelCategory')
         pob = container.get('pressure')
@@ -80,6 +84,7 @@ class AdpupaPrepbufrObsBuilder(PrepbufrObsBuilder):
         container.add('stationPressure', station_pressure, ydr_paths)
         container.add('stationPressureQualityMarker', station_pressureQM, ydr_paths)
         container.add('stationPressureError', station_pressureError, ydr_paths)
+        container.add('obsSubType', obsSubType, ydr_paths)
 
         self.log.debug(f'container list (updated): {container.list()}')
 
@@ -107,6 +112,36 @@ class AdpupaPrepbufrObsBuilder(PrepbufrObsBuilder):
                 'units': 'Pa',
                 'longName': 'Station Pressure Error',
             },
+            {
+                'name': 'ObsSubType/stationPressure',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/airTemperature',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/virtualTemperature',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/specificHumidity',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/windEastward',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/windNorthward',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            }
         ])
 
         return description

--- a/dump/scripts/atmosphere/prepbufr_sfcshp.py
+++ b/dump/scripts/atmosphere/prepbufr_sfcshp.py
@@ -84,7 +84,7 @@ class SfcshpPrepbufrObsBuilder(PrepbufrObsBuilder):
         dhr2 = np.array(dhr)
         self._replace_timestamp(container, self._get_reference_time(input_path))
 
-        self.log.debug(f'Do ObsSubType and sequenceNumber calculation')
+        self.log.debug(f'Do ObsSubType and sequenceNumber calculations')
         typ = container.get('observationType')
         typ_paths = container.get_paths('observationType')
         t29 = container.get('observationSubTypeNum')

--- a/dump/scripts/atmosphere/prepbufr_sfcshp.py
+++ b/dump/scripts/atmosphere/prepbufr_sfcshp.py
@@ -144,13 +144,9 @@ class SfcshpPrepbufrObsBuilder(PrepbufrObsBuilder):
             Masked array of obsSubType values
         """
 
-        obsSubType = np.zeros(typ.shape, dtype=np.int32)
-        for i in range(len(typ)):
-            if (typ[i] == 180 or typ[i] == 280):
-                if (t29[i] > 555 and t29[i] < 565):
-                    obsSubType[i] = 0
-                else:
-                    obsSubType[i] = 1
+        mask_typ = np.isin(typ, [180, 280])
+        mask_t29 = (t29 > 555) & (t29 < 565)
+        obsSubType = np.where(mask_typ & ~mask_t29, 1, 0).astype(np.int32)
 
         return obsSubType
 

--- a/dump/scripts/atmosphere/prepbufr_sfcshp.py
+++ b/dump/scripts/atmosphere/prepbufr_sfcshp.py
@@ -62,7 +62,7 @@ class SfcshpPrepbufrObsBuilder(PrepbufrObsBuilder):
         """
         Create the ioda sfcshp prepbufr observations:
         - reads values
-        - adds ObsSubType 
+        - adds ObsSubType and sequenceNumber
 
         Parameters
         ----------

--- a/dump/scripts/atmosphere/prepbufr_sfcshp.py
+++ b/dump/scripts/atmosphere/prepbufr_sfcshp.py
@@ -124,6 +124,8 @@ class SfcshpPrepbufrObsBuilder(PrepbufrObsBuilder):
         container.replace('virtualTemperatureObsError', tvooe)
 
         self.log.debug(f'Add variables to container')
+        # Both 'sequenceNumber' and 'obsSubType' are populated with identical arrays.
+        # This is intentional for compatibility with downstream consumers that may expect either field.
         container.add('sequenceNumber', obsSubType, typ_paths)
         container.add('obsSubType', obsSubType, typ_paths)
 

--- a/dump/scripts/atmosphere/prepbufr_sfcshp.py
+++ b/dump/scripts/atmosphere/prepbufr_sfcshp.py
@@ -24,6 +24,36 @@ class SfcshpPrepbufrObsBuilder(PrepbufrObsBuilder):
                 'name': 'MetaData/sequenceNumber',
                 'source': 'sequenceNumber',
                 'longName': 'Sequence Number (Obs Subtype)',
+            },
+            {
+                'name': 'ObsSubType/stationPressure',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/airTemperature',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/virtualTemperature',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/specificHumidity',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/windEastward',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            },
+            {
+                'name': 'ObsSubType/windNorthward',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
             }
         ])
         return description
@@ -32,7 +62,7 @@ class SfcshpPrepbufrObsBuilder(PrepbufrObsBuilder):
         """
         Create the ioda sfcshp prepbufr observations:
         - reads values
-        - adds sequenceNum
+        - adds ObsSubType 
 
         Parameters
         ----------
@@ -54,13 +84,13 @@ class SfcshpPrepbufrObsBuilder(PrepbufrObsBuilder):
         dhr2 = np.array(dhr)
         self._replace_timestamp(container, self._get_reference_time(input_path))
 
-        self.log.debug(f'Do sequenceNumber (Obs SubType) calculation')
+        self.log.debug(f'Do ObsSubType and sequenceNumber calculation')
         typ = container.get('observationType')
         typ_paths = container.get_paths('observationType')
         t29 = container.get('observationSubTypeNum')
         t29_paths = container.get_paths('observationSubTypeNum')
-        seqNum = self._compute_sequence_number(typ, t29)
-        self.log.debug(f' sequenceNum min/max =  {seqNum.min()} {seqNum.max()}')
+        obsSubType = self._compute_obssubtype(typ, t29)
+        self.log.debug(f' obsSubType min/max =  {obsSubType.min()} {obsSubType.max()}')
 
         self.log.debug(f'Do tsen and tv calculation')
         tpc = container.get('temperatureEventCode')
@@ -94,34 +124,35 @@ class SfcshpPrepbufrObsBuilder(PrepbufrObsBuilder):
         container.replace('virtualTemperatureObsError', tvooe)
 
         self.log.debug(f'Add variables to container')
-        container.add('sequenceNumber', seqNum, typ_paths)
+        container.add('sequenceNumber', obsSubType, typ_paths)
+        container.add('obsSubType', obsSubType, typ_paths)
 
         # Check
         self.log.debug(f'container list (updated): {container.list()}')
 
         return container
 
-    def _compute_sequence_number(self, typ, t29):
+    def _compute_obssubtype(self, typ, t29):
         """
-        Compute sequenceNumber
+        Compute obsSubType group
 
         Parameters:
             typ: observation Type (obsType)
             t29: data dump report type
 
         Returns:
-            Masked array of sequenceNumber values
+            Masked array of obsSubType values
         """
 
-        sequenceNumber = np.zeros(typ.shape, dtype=np.int32)
+        obsSubType = np.zeros(typ.shape, dtype=np.int32)
         for i in range(len(typ)):
             if (typ[i] == 180 or typ[i] == 280):
                 if (t29[i] > 555 and t29[i] < 565):
-                    sequenceNumber[i] = 0
+                    obsSubType[i] = 0
                 else:
-                    sequenceNumber[i] = 1
+                    obsSubType[i] = 1
 
-        return sequenceNumber
+        return obsSubType
 
 
 add_main_functions(SfcshpPrepbufrObsBuilder)

--- a/ush/test/config/bufr_bufr4backend_adpsfc_prepbufr.yaml
+++ b/ush/test/config/bufr_bufr4backend_adpsfc_prepbufr.yaml
@@ -1,6 +1,6 @@
 time window:
   begin: "1969-07-31T21:00:00Z"
-  end: "2021-08-01T03:00:00Z"
+  end: "2024-02-19T03:00:00Z"
   bound to include: begin
 
 observations:
@@ -10,9 +10,9 @@ observations:
     obsdatain:
       engine:
         type: bufr
-        obsfile: "./testinput/2021080100/gdas.t00z.prepbufr"
+        obsfile: "./testinput/2024021900/gdas.t00z.prepbufr"
         mapping file: "./prepbufr_adpsfc.yaml"
     obsdataout:
       engine:
         type: H5File
-        obsfile: "./testoutput/2021080100/bufr4backend/gdas.t00z.adpsfc_prepbufr.tm00.nc"
+        obsfile: "./testoutput/2024021900/bufr4backend/gdas.t00z.adpsfc_prepbufr.tm00.nc"

--- a/ush/test/config/bufr_bufr4backend_adpupa_prepbufr.yaml
+++ b/ush/test/config/bufr_bufr4backend_adpupa_prepbufr.yaml
@@ -1,16 +1,16 @@
 time window:
-  begin: "2021-07-31T21:00:00Z"
-  end: "2021-08-01T03:00:00Z"
+  begin: "2024-02-18T21:00:00Z"
+  end: "2024-02-19T03:00:00Z"
   bound to include: begin
 
 observations:
 - obs space:
     name: "ADPUPA"
-    simulated variables: [airTemperature, virtualTemperature, windEastward, windNorthward, specificHumidity]
+    simulated variables: ['airTemperature', 'virtualTemperature', 'windEastward', 'windNorthward', 'specificHumidity']
     obsdatain:
       engine:
         type: bufr 
-        obsfile: "./testinput/2021080100/gdas.t00z.prepbufr"
+        obsfile: "./testinput/2024021900/gdas.t00z.prepbufr"
         mapping file: "./prepbufr_adpupa.yaml"
     obsgrouping:
       group variables: ["stationIdentification"]
@@ -19,4 +19,4 @@ observations:
     obsdataout:
       engine:
         type: H5File
-        obsfile: "./testoutput/2021080100/bufr4backend/gdas.t00z.adpupa_prepbufr.tm00.nc"
+        obsfile: "./testoutput/2024021900/bufr4backend/gdas.t00z.adpupa_prepbufr.tm00.nc"

--- a/ush/test/config/bufr_bufr4backend_sfcshp_prepbufr.yaml
+++ b/ush/test/config/bufr_bufr4backend_sfcshp_prepbufr.yaml
@@ -1,6 +1,6 @@
 time window:
   begin: "1969-07-31T21:00:00Z"
-  end: "2021-08-01T03:00:00Z"
+  end: "2024-02-19T03:00:00Z"
   bound to include: begin
 
 observations:
@@ -10,9 +10,9 @@ observations:
     obsdatain:
       engine:
         type: bufr
-        obsfile: "./testinput/2021080100/gdas.t00z.prepbufr"
+        obsfile: "./testinput/2024021900/gdas.t00z.prepbufr"
         mapping file: "./prepbufr_sfcshp.yaml"
     obsdataout:
       engine:
         type: H5File
-        obsfile: "./testoutput/2021080100/bufr4backend/gdas.t00z.sfcshp_prepbufr.tm00.nc"
+        obsfile: "./testoutput/2024021900/bufr4backend/gdas.t00z.sfcshp_prepbufr.tm00.nc"

--- a/ush/test/config/bufr_script4backend_adpsfc_prepbufr.yaml
+++ b/ush/test/config/bufr_script4backend_adpsfc_prepbufr.yaml
@@ -1,6 +1,6 @@
 time window:
-  begin: "2021-07-31T21:00:00Z"
-  end: "2021-08-01T03:00:00Z"
+  begin: "2024-02-18T21:00:00Z"
+  end: "2024-02-19T03:00:00Z"
   bound to include: begin
 
 observations:
@@ -14,9 +14,8 @@ observations:
         type: script
         script file: "prepbufr_adpsfc.py"
         args:
-          input: "./testinput/2021080100/gdas.t00z.prepbufr"
-          mapping_path: "./prepbufr_adpsfc.yaml"
+          input: "./testinput/2024021900/gdas.t00z.prepbufr"
     obsdataout:
       engine:
         type: H5File
-        obsfile: "./testoutput/2021080100/script4backend/gdas.t00z.adpsfc_prepbufr.tm00.nc"
+        obsfile: "./testoutput/2024021900/script4backend/gdas.t00z.adpsfc_prepbufr.tm00.nc"

--- a/ush/test/config/bufr_script4backend_adpupa_prepbufr.yaml
+++ b/ush/test/config/bufr_script4backend_adpupa_prepbufr.yaml
@@ -1,20 +1,18 @@
 time window:
-  begin: "2021-07-31T21:00:00Z"
-  end: "2021-08-01T03:00:00Z"
+  begin: "2024-02-18T21:00:00Z"
+  end: "2024-02-19T03:00:00Z"
   bound to include: begin
 
 observations:
 - obs space:
     name: "ADPUPA"
-    simulated variables: [airTemperature, virtualTemperature, windEastward, windNorthward, specificHumidity]
+    simulated variables: ['airTemperature', 'virtualTemperature', 'windEastward', 'windNorthward', 'specificHumidity']
     obsdatain:
       engine:
         type: script 
         script file: "./prepbufr_adpupa.py"
         args:
-          input_path: "./testinput/2021080100/gdas.t00z.prepbufr"
-          mapping_path: "./prepbufr_adpupa.yaml"
-          cycle_time: "2021080100"
+          input: "./testinput/2024021900/gdas.t00z.prepbufr"
     obsgrouping:
       group variables: ["stationIdentification"]
       sort variable: "pressure"
@@ -22,4 +20,4 @@ observations:
     obsdataout:
       engine:
         type: H5File
-        obsfile: "./testoutput/2021080100/script4backend/gdas.t00z.adpupa_prepbufr.tm00.nc"
+        obsfile: "./testoutput/2024021900/script4backend/gdas.t00z.adpupa_prepbufr.tm00.nc"

--- a/ush/test/config/bufr_script4backend_sfcshp_prepbufr.yaml
+++ b/ush/test/config/bufr_script4backend_sfcshp_prepbufr.yaml
@@ -1,6 +1,6 @@
 time window:
-  begin: "2021-07-31T21:00:00Z"
-  end: "2021-08-01T03:00:00Z"
+  begin: "2024-02-18T21:00:00Z"
+  end: "2024-02-19T03:00:00Z"
   bound to include: begin
 
 observations:
@@ -14,9 +14,8 @@ observations:
         type: script
         script file: "prepbufr_sfcshp.py"
         args:
-          input: "testinput/2021080100/gdas.t00z.prepbufr"
-          mapping_path: "./prepbufr_sfcshp.yaml"
+          input: "testinput/2024021900/gdas.t00z.prepbufr"
     obsdataout:
       engine:
         type: H5File
-        obsfile: "./testoutput/2021080100/script4backend/gdas.t00z.sfcshp_prepbufr.tm00.nc"
+        obsfile: "./testoutput/2024021900/script4backend/gdas.t00z.sfcshp_prepbufr.tm00.nc"


### PR DESCRIPTION
Adds ObsSubType to scripts that use it (SFCSHP, ADPSFC, ADPUPA). ADPUPA and ADPSFC are all zeros because they are not influenced by anything. SFCSHP is the only one that is influenced by it. Some minor updates were made to the yamls for the newest date of test data.

Fixes #84 