### PR TITLE
change heightOfStation to height

### DIFF
--- a/dump/config/atmosphere/prepbufr_aircraft.yaml
+++ b/dump/config/atmosphere/prepbufr_aircraft.yaml
@@ -41,7 +41,7 @@ bufr:
       query: "*/PRSLEVLA/DRFTINFO/YDR"
     obsTimeMinusCycleTime:
       query: "*/PRSLEVLA/DRFTINFO/HRDR"
-    heightOfStationMetaData: #Formerly aircraftFlightLevel
+    heightMetaData: #Formerly aircraftFlightLevel
       query: "*/PRSLEVLA/Z___INFO/Z__EVENT{1}/ZOB"
     stationElevationMetaData:
       query: "*/ELV"
@@ -182,8 +182,8 @@ encoder:
       longName: "Pressure"
       units: "Pa"
 
-    - name: "MetaData/heightOfStation"
-      source: variables/heightOfStationMetaData
+    - name: "MetaData/height"
+      source: variables/heightMetaData
       longName: "Height Of Station"
       units: "m"
 


### PR DESCRIPTION
MetaData/heightOfStation for aircraft needed to be updated to MetaData/height in order for the workflow to work.

This fixes issue #99

The obsforge hash will need to be updated once this is done. 
ATTN: @CoryMartin-NOAA @HyundeokChoi-NOAA 