### PR TITLE
Replace empty string in AVHRR YAML

### DIFF
--- a/dump/config/atmosphere/radiance_avhrr.yaml
+++ b/dump/config/atmosphere/radiance_avhrr.yaml
@@ -75,7 +75,7 @@ encoder:
 
     - name: "sensorLongDescription"
       type: string
-      value: ""
+      value: "Advanced Very-High-Resolution Radiometer"
 
     - name: "source"
       type: string


### PR DESCRIPTION
Discovered by @gmao-wgu the AVHRR IODA files were unreadable by IODA. Turns out it was due to an empty string global attribute. Instead of removing it, this PR puts the appropriate string in the attribute.