### PR TITLE
Update configuration YAML files to read RSRD/EXPRSRD variables

### DIFF
--- a/dump/config/atmosphere/gnssro.yaml
+++ b/dump/config/atmosphere/gnssro.yaml
@@ -24,6 +24,12 @@ bufr:
       transforms:
         - scale: 0.017453292519943
 
+    # Restriction
+    restrictionFlag:
+      query: "*/RSRD"
+    restrictionExpiration:
+      query: "*/EXPRSRD"
+
     satelliteId:
       query: "*/SAID"
     satelliteInstrument:
@@ -177,6 +183,16 @@ encoder:
       source: variables/timestamp
       units: "seconds since 1970-01-01T00:00:00Z" 
       longName: "Datetime" 
+
+    # Restriction on Redistribution
+    - name: "MetaData/restrictionFlag"
+      source: variables/restrictionFlag
+      longName: "Restriction on Redistribution"
+
+    # Expiration of Restriction on Redistribution  
+    - name: "MetaData/restrictionExpiration"
+      source: variables/restrictionExpiration
+      longName: "Expiration of Restriction on Redistribution"
 
     # Satellite Identifier
     - name: "MetaData/satelliteIdentifier"

--- a/dump/config/atmosphere/prepbufr_adpsfc.yaml
+++ b/dump/config/atmosphere/prepbufr_adpsfc.yaml
@@ -23,6 +23,10 @@ bufr:
       query: "*/CAT"
     obsTimeMinusCycleTime:
       query: "*/DHR"
+    restrictionFlag:
+      query: "*/RSRD_SEQ/RSRD"
+    restrictionExpiration:
+      query: "*/RSRD_SEQ/EXPRSRD"
     longitude:
       query: "*/XOB"
       transforms:
@@ -176,6 +180,14 @@ encoder:
       source: variables/timestamp
       units: 'seconds since 1970-01-01T00:00:00Z'
       longName: 'dateTime'
+
+    - name: "MetaData/restrictionFlag"
+      source: variables/restrictionFlag
+      longName: "Restriction on Redistribution"
+      
+    - name: "MetaData/restrictionExpiration"
+      source: variables/restrictionExpiration
+      longName: "Expiration of Restriction on Redistribution"
 
     - name: "MetaData/latitude"
       source: variables/latitude

--- a/dump/config/atmosphere/prepbufr_adpupa.yaml
+++ b/dump/config/atmosphere/prepbufr_adpupa.yaml
@@ -26,6 +26,10 @@ bufr:
       query: "*/PRSLEVEL/CAT"
     obsTimeMinusCycleTime:
       query: "*/PRSLEVEL/DRFTINFO/HRDR"
+    restrictionFlag:
+      query: "*/RSRD_SEQ/RSRD"
+    restrictionExpiration:
+      query: "*/RSRD_SEQ/EXPRSRD"      
     longitude:
       query: "*/PRSLEVEL/DRFTINFO/XDR"
       transforms:
@@ -175,6 +179,16 @@ encoder:
       source: variables/stationIdentification
       longName: "Station Identification"
 
+    # Restriction on Redistribution
+    - name: "MetaData/restrictionFlag"
+      source: variables/restrictionFlag
+      longName: "Restriction on Redistribution"
+      
+    # Expiration of Restriction on Redistribution  
+    - name: "MetaData/restrictionExpiration"
+      source: variables/restrictionExpiration
+      longName: "Expiration of Restriction on Redistribution"
+    
     # MetaData: longitude
     - name: "MetaData/longitude"
       source: variables/longitude

--- a/dump/config/atmosphere/prepbufr_aircraft.yaml
+++ b/dump/config/atmosphere/prepbufr_aircraft.yaml
@@ -33,6 +33,12 @@ bufr:
       query: "*/T29"
     aircraftFlightNumber:
       query: "[*/ACID, */ACID_SEQ/ACID]"
+
+    restrictionFlag:
+      query: "*/RSRD_SEQ/RSRD"
+    restrictionExpiration:
+      query: "*/RSRD_SEQ/EXPRSRD"      
+
     longitude:
       query: "*/PRSLEVLA/DRFTINFO/XDR"
       transforms:
@@ -159,6 +165,14 @@ encoder:
     - name: "MetaData/aircraftFlightNumber"
       source: variables/aircraftFlightNumber
       longName: "Aircraft Flight Number"
+
+    - name: "MetaData/restrictionFlag"
+      source: variables/restrictionFlag
+      longName: "Restriction on Redistribution"
+
+    - name: "MetaData/restrictionExpiration"
+      source: variables/restrictionExpiration
+      longName: "Expiration of Restriction on Redistribution"
 
     - name: "MetaData/latitude"
       source: variables/latitude

--- a/dump/config/atmosphere/prepbufr_sfcshp.yaml
+++ b/dump/config/atmosphere/prepbufr_sfcshp.yaml
@@ -23,6 +23,10 @@ bufr:
         referenceTime: "1970-01-01T00:00:00Z"
     obsTimeMinusCycleTime:
       query: "*/DHR"
+    restrictionFlag:
+      query: "*/RSRD_SEQ/RSRD"
+    restrictionExpiration:
+      query: "*/RSRD_SEQ/EXPRSRD"      
     longitude:
       query: "*/XOB"
       transforms:
@@ -172,6 +176,14 @@ encoder:
     - name: "MetaData/observationSubTypeNum"
       source: variables/observationSubTypeNum
       longName: "Observation SubType Number"
+
+    - name: "MetaData/restrictionFlag"
+      source: variables/restrictionFlag
+      longName: "Restriction on Redistribution"
+
+    - name: "MetaData/restrictionExpiration"
+      source: variables/restrictionExpiration
+      longName: "Expiration of Restriction on Redistribution"
 
     - name: "MetaData/latitude"
       source: variables/latitude


### PR DESCRIPTION
This PR updates the SPOC configuration YAML files to enable extraction of the BUFR restriction variables RSRD (Restriction Flag) and EXPRSRD (Restriction Expiration). These variables are required for downstream restriction‑screening logic in ioda_restriction_filter.py.