### PR TITLE
Add GSI's Tsensible option

### DIFF
--- a/dump/config/atmosphere/prepbufr_adpsfc.yaml
+++ b/dump/config/atmosphere/prepbufr_adpsfc.yaml
@@ -43,9 +43,52 @@ bufr:
     stationElevation:
       query: "*/ELV"
       type: float
-    temperatureEventCode:
-      query: "*/T___INFO/T__EVENT{1}/TPC"
 
+    # Temperature event codes for each event level (to find Tdry vs Tv)
+    temperatureEventCode1:
+      query: "*/T___INFO/T__EVENT{1}/TPC"
+    temperatureEventCode2:
+      query: "*/T___INFO/T__EVENT{2}/TPC"
+    temperatureEventCode3:
+      query: "*/T___INFO/T__EVENT{3}/TPC"
+    temperatureEventCode4:
+      query: "*/T___INFO/T__EVENT{4}/TPC"
+    temperatureEventCode5:
+      query: "*/T___INFO/T__EVENT{5}/TPC"
+
+    # Temperature observations for each event level
+    temperatureOb1:
+      query: "*/T___INFO/T__EVENT{1}/TOB"
+      transforms:
+        - offset: 273.15
+    temperatureOb2:
+      query: "*/T___INFO/T__EVENT{2}/TOB"
+      transforms:
+        - offset: 273.15
+    temperatureOb3:
+      query: "*/T___INFO/T__EVENT{3}/TOB"
+      transforms:
+        - offset: 273.15
+    temperatureOb4:
+      query: "*/T___INFO/T__EVENT{4}/TOB"
+      transforms:
+        - offset: 273.15
+    temperatureOb5:
+      query: "*/T___INFO/T__EVENT{5}/TOB"
+      transforms:
+        - offset: 273.15
+
+    # Temperature quality markers for each event level
+    temperatureQM1:
+      query: "*/T___INFO/T__EVENT{1}/TQM"
+    temperatureQM2:
+      query: "*/T___INFO/T__EVENT{2}/TQM"
+    temperatureQM3:
+      query: "*/T___INFO/T__EVENT{3}/TQM"
+    temperatureQM4:
+      query: "*/T___INFO/T__EVENT{4}/TQM"
+    temperatureQM5:
+      query: "*/T___INFO/T__EVENT{5}/TQM"
 
     # ObsValue
     stationPressureObsValue:
@@ -207,10 +250,6 @@ encoder:
       source: variables/stationElevation
       longName: "Station Elevation"
       units: "m"
-
-    - name: "MetaData/temperatureEventCode"
-      source: variables/temperatureEventCode
-      longName: "Temperature Event Code"
 
     # ObsValue
     - name: "ObsValue/stationPressure"

--- a/dump/config/atmosphere/prepbufr_adpsfc.yaml
+++ b/dump/config/atmosphere/prepbufr_adpsfc.yaml
@@ -95,14 +95,8 @@ bufr:
       query: "*/P___INFO/P__EVENT{1}/POB"
       transforms:
         - scale: 100
-    airTemperatureObsValue:
-      query: "*/T___INFO/T__EVENT{1}/TOB"
-      transforms:
-        - offset: 273.15
-    virtualTemperatureObsValue:
-      query: "*/T___INFO/T__EVENT{1}/TOB"
-      transforms:
-        - offset: 273.15
+    # airTemperature and virtualTemperature ObsValues are computed in Python
+    # from temperatureOb{i} and temperatureEventCode{i} event stacks
     specificHumidityObsValue:
       type: float
       query: "*/Q___INFO/Q__EVENT{1}/QOB"
@@ -116,10 +110,6 @@ bufr:
     # QualityMarker
     stationPressureQualityMarker:
       query: "*/P___INFO/P__EVENT{1}/PQM"
-    airTemperatureQualityMarker:
-      query: "*/T___INFO/T__EVENT{1}/TQM"
-    virtualTemperatureQualityMarker:
-      query: "*/T___INFO/T__EVENT{1}/TQM"
     specificHumidityQualityMarker:
       query: "*/Q___INFO/Q__EVENT{1}/QQM"
     windEastwardQualityMarker:
@@ -134,8 +124,7 @@ bufr:
         - scale: 100
     airTemperatureObsError:
       query: "*/T___INFO/T__BACKG/TOE"
-    virtualTemperatureObsError:
-      query: "*/T___INFO/T__BACKG/TOE"
+    # virtualTemperatureObsError computed in Python from airTemperatureObsError
     relativeHumidityObsError:
       query: "*/Q___INFO/Q__BACKG/QOE"
       transforms:

--- a/dump/config/atmosphere/prepbufr_adpsfc_Tdry.yaml
+++ b/dump/config/atmosphere/prepbufr_adpsfc_Tdry.yaml
@@ -152,7 +152,7 @@ encoder:
 
     - name: "source"
       type: string
-      value: "U.S. National Weather Service, National Centers for Environmental Prediction (NCEP))"
+      value: "U.S. National Weather Service, National Centers for Environmental Prediction (NCEP)"
 
     - name: "sourceFiles"
       type: string

--- a/dump/config/atmosphere/prepbufr_adpsfc_Tdry.yaml
+++ b/dump/config/atmosphere/prepbufr_adpsfc_Tdry.yaml
@@ -23,6 +23,10 @@ bufr:
       query: "*/CAT"
     obsTimeMinusCycleTime:
       query: "*/DHR"
+    restrictionFlag:
+      query: "*/RSRD_SEQ/RSRD"
+    restrictionExpiration:
+      query: "*/RSRD_SEQ/EXPRSRD"
     longitude:
       query: "*/XOB"
       transforms:
@@ -201,6 +205,14 @@ encoder:
       source: variables/timestamp
       units: 'seconds since 1970-01-01T00:00:00Z'
       longName: 'dateTime'
+
+    - name: "MetaData/restrictionFlag"
+      source: variables/restrictionFlag
+      longName: "Restriction on Redistribution"
+      
+    - name: "MetaData/restrictionExpiration"
+      source: variables/restrictionExpiration
+      longName: "Expiration of Restriction on Redistribution"
 
     - name: "MetaData/latitude"
       source: variables/latitude

--- a/dump/config/atmosphere/prepbufr_adpsfc_Tdry.yaml
+++ b/dump/config/atmosphere/prepbufr_adpsfc_Tdry.yaml
@@ -174,10 +174,6 @@ encoder:
       source: variables/observationType
       longName: "airTemperature ObsType"
 
-    - name: "ObsType/virtualTemperature"
-      source: variables/observationType
-      longName: "virtualTemperature ObsType"
-
     - name: "ObsType/specificHumidity"
       source: variables/observationType
       longName: "Specific Humidity ObsType"
@@ -248,11 +244,6 @@ encoder:
       longName: "airTemperature"
       units: "K"
 
-    - name: "ObsValue/virtualTemperature"
-      source: variables/virtualTemperatureObsValue
-      longName: "virtualTemperature"
-      units: "K"
-
     - name: "ObsValue/specificHumidity"
       source: variables/specificHumidityObsValue
       longName: "Specific Humidity"
@@ -277,10 +268,6 @@ encoder:
       source: variables/airTemperatureQualityMarker
       longName: "airTemperature Quality Marker"
 
-    - name: "QualityMarker/virtualTemperature"
-      source: variables/virtualTemperatureQualityMarker
-      longName: "virtualTemperature Quality Marker"
-
     - name: "QualityMarker/specificHumidity"
       source: variables/specificHumidityQualityMarker
       longName: "Specific Humidity Quality Marker"
@@ -302,11 +289,6 @@ encoder:
     - name: "ObsError/airTemperature"
       source: variables/airTemperatureObsError
       longName: "airTemperature Error"
-      units: "K"
-
-    - name: "ObsError/virtualTemperature"
-      source: variables/virtualTemperatureObsError
-      longName: "virtualTemperature Error"
       units: "K"
 
     - name: "ObsError/specificHumidity"

--- a/dump/scripts/atmosphere/prepbufr_adpsfc.py
+++ b/dump/scripts/atmosphere/prepbufr_adpsfc.py
@@ -11,6 +11,15 @@ from prepbufr_obs_builder import PrepbufrObsBuilder, map_path
 
 MAPPING_PATH = map_path('prepbufr_adpsfc.yaml')
 
+# Number of temperature event levels read from YAML
+NUM_T_EVENTS = 5
+
+# Flag to mimi GSI's TSENSIBLE option. 
+# True: Use sensible/dry temperature (Tdry) by searching through event stack
+# False: Use Tv if available (TPC=8), otherwise Tdry (TPC 1-7), 
+#        for testing against GSI only.
+TSENSIBLE = True
+
 
 class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
     def __init__(self):
@@ -65,6 +74,7 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
         - reads values
         - adds sequenceNum
         - adds ObsSubType
+        - extracts Tdry from event stack (peels back through events if top is Tv)
 
         Parameters
         ----------
@@ -92,28 +102,57 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
         sequenceNum = np.zeros(dhr.shape, dtype=np.int32)
         self.log.debug(f' sequenceNum min/max =  {sequenceNum.min()} {sequenceNum.max()}')
 
-        self.log.debug(f'Do tsen and tv calculation')
-        tpc = container.get('temperatureEventCode')
-        tob = container.get('airTemperatureObsValue')
-        tob_paths = container.get_paths('airTemperatureObsValue')
-        tsen = np.full(tob.shape[0], tob.fill_value)
-        tsen = np.where(((tpc >= 1) & (tpc < 8)), tob, tsen)
-        tvo = np.full(tob.shape[0], tob.fill_value)
-        tvo = np.where((tpc == 8), tob, tvo)
+        self.log.debug(f'Extract temperature from event stack (tsensible={TSENSIBLE})')
 
-        self.log.debug(f'Do tsen and tv QM calculations')
-        tobqm = container.get('airTemperatureQualityMarker')
-        tsenqm = np.full(tobqm.shape[0], tobqm.fill_value)
-        tsenqm = np.where(((tpc >= 1) & (tpc < 8)), tobqm, tsenqm)
-        tvoqm = np.full(tobqm.shape[0], tobqm.fill_value)
-        tvoqm = np.where((tpc == 8), tobqm, tvoqm)
+        # Get temperature data from all event levels
+        tpc_events = []
+        tob_events = []
+        tqm_events = []
+        for i in range(1, NUM_T_EVENTS + 1):
+            tpc_events.append(container.get(f'temperatureEventCode{i}'))
+            tob_events.append(container.get(f'temperatureOb{i}'))
+            tqm_events.append(container.get(f'temperatureQM{i}'))
 
-        self.log.debug(f'Do tsen and tv ObsError calculations')
+        # Get ObsError (from T__BACKG, not event-specific)
         toboe = container.get('airTemperatureObsError')
-        tsenoe = np.full(toboe.shape[0], toboe.fill_value)
-        tsenoe = np.where(((tpc >= 1) & (tpc < 8)), toboe, tsenoe)
-        tvooe = np.full(toboe.shape[0], toboe.fill_value)
-        tvooe = np.where((tpc == 8), toboe, tvooe)
+
+        # Get fill values from each variable type
+        tob_fill = tob_events[0].fill_value
+        tqm_fill = tqm_events[0].fill_value
+        toe_fill = toboe.fill_value
+
+        # Initialize output arrays with appropriate fill values
+        n_obs = tob_events[0].shape[0]
+        tsen = np.full(n_obs, tob_fill)
+        tsenqm = np.full(n_obs, tqm_fill)
+        tsenoe = np.full(n_obs, toe_fill)
+        tvo = np.full(n_obs, tob_fill)
+        tvoqm = np.full(n_obs, tqm_fill)
+        tvooe = np.full(n_obs, toe_fill)
+
+        # Search through events for each observation
+        for idx in range(n_obs):
+            for ev in range(NUM_T_EVENTS):
+                tpc_val = tpc_events[ev][idx]
+                tob_val = tob_events[ev][idx]
+                tqm_val = tqm_events[ev][idx]
+
+                # Skip if obs masked/missing
+                if ma.is_masked(tpc_val) or ma.is_masked(tob_val):
+                    continue
+
+                if tpc_val == 8 and ( not TSENSIBLE ):
+                    # use Tv if available
+                    tvo[idx] = tob_val
+                    tvoqm[idx] = tqm_val
+                    tvooe[idx] = toboe[idx]
+                    break
+                elif (tpc_val >= 1) and (tpc_val < 8):
+                    # Save Tdry
+                    tsen[idx] = tob_val
+                    tsenqm[idx] = tqm_val
+                    tsenoe[idx] = toboe[idx]
+                    break
 
         self.log.debug(f'Update variables in container')
         container.replace('airTemperatureObsValue', tsen)
@@ -134,3 +173,4 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
 
 
 add_main_functions(AdpsfcPrepbufrObsBuilder)
+

--- a/dump/scripts/atmosphere/prepbufr_adpsfc.py
+++ b/dump/scripts/atmosphere/prepbufr_adpsfc.py
@@ -12,7 +12,7 @@ from prepbufr_obs_builder import PrepbufrObsBuilder, map_path
 
 MAPPING_PATH = map_path('prepbufr_adpsfc.yaml')
 
-# Number of temperature event levels read from YAML
+# Fixed number of temperature event levels handled by this builder.
 NUM_T_EVENTS = 5
 
 # - If ObsType/virtualTemperature is in the encoder variables, use Tv if available otherwise Tdry.

--- a/dump/scripts/atmosphere/prepbufr_adpsfc.py
+++ b/dump/scripts/atmosphere/prepbufr_adpsfc.py
@@ -20,8 +20,8 @@ NUM_T_EVENTS = 5
 # - If ObsType/virtualTemperature not in encoder variables, always use Tdry
 #   This is what we want to do long-term
 
-# obs types 181, 183, 187 (land stations) always use Tdry to match GSI behavior
-TSENSIBLE_EXCEPTION_TYPES = [181, 183, 187]
+# obs types 181, 183 (land stations) always use Tdry to match GSI behavior
+TSENSIBLE_EXCEPTION_TYPES = [181, 187]
 
 
 def _check_include_tv(yaml_path):
@@ -38,7 +38,7 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
     def _make_description(self):
         description = super()._make_description()
 
-        description.add_variables([
+        variables = [
             {
                 'name': 'MetaData/sequenceNumber',
                 'source': 'sequenceNumber',
@@ -51,11 +51,6 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
             },
             {
                 'name': 'ObsSubType/airTemperature',
-                'source': 'obsSubType',
-                'longName': 'Observation SubType',
-            },
-            {
-                'name': 'ObsSubType/virtualTemperature',
                 'source': 'obsSubType',
                 'longName': 'Observation SubType',
             },
@@ -74,7 +69,16 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
                 'source': 'obsSubType',
                 'longName': 'Observation SubType',
             }
-        ])
+        ]
+
+        if _check_include_tv(MAPPING_PATH):
+            variables.append({
+                'name': 'ObsSubType/virtualTemperature',
+                'source': 'obsSubType',
+                'longName': 'Observation SubType',
+            })
+
+        description.add_variables(variables)
 
         return description
 
@@ -131,18 +135,14 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
         # get paths for adding new variables
         tob_paths = container.get_paths('temperatureOb1')
 
-        # create arrays with fill_value
-        tob_fill = tob_events[0].fill_value
-        tqm_fill = tqm_events[0].fill_value
-        toe_fill = toboe.fill_value
-
+        # create arrays with fill_value (matching develop branch pattern)
         n_obs = tob_events[0].shape[0]
-        tsen = np.full(n_obs, tob_fill)
-        tsenqm = np.full(n_obs, tqm_fill)
-        tsenoe = np.full(n_obs, toe_fill)
-        tvo = np.full(n_obs, tob_fill)
-        tvoqm = np.full(n_obs, tqm_fill)
-        tvooe = np.full(n_obs, toe_fill)
+        tsen = np.full(n_obs, tob_events[0].fill_value)
+        tsenqm = np.full(n_obs, tqm_events[0].fill_value)
+        tsenoe = np.full(n_obs, toboe.fill_value)
+        tvo = np.full(n_obs, tob_events[0].fill_value)
+        tvoqm = np.full(n_obs, tqm_events[0].fill_value)
+        tvooe = np.full(n_obs, toboe.fill_value)
 
         # loop through obs
         for idx in range(n_obs):
@@ -161,14 +161,18 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
                 if tpc_val == 8 and use_tv:
                     # use Tv if available
                     tvo[idx] = tob_val
-                    tvoqm[idx] = tqm_val
-                    tvooe[idx] = toboe[idx]
+                    if not ma.is_masked(tqm_val):
+                        tvoqm[idx] = tqm_val
+                    if not ma.is_masked(toboe[idx]):
+                        tvooe[idx] = toboe[idx]
                     break
                 elif (tpc_val >= 1) and (tpc_val < 8):
                     # Save Tdry
                     tsen[idx] = tob_val
-                    tsenqm[idx] = tqm_val
-                    tsenoe[idx] = toboe[idx]
+                    if not ma.is_masked(tqm_val):
+                        tsenqm[idx] = tqm_val
+                    if not ma.is_masked(toboe[idx]):
+                        tsenoe[idx] = toboe[idx]
                     break
 
         self.log.debug(f'Update variables in container')

--- a/dump/scripts/atmosphere/prepbufr_adpsfc.py
+++ b/dump/scripts/atmosphere/prepbufr_adpsfc.py
@@ -3,6 +3,7 @@ import calendar
 import os
 import numpy as np
 import numpy.ma as ma
+import yaml
 
 import bufr
 from bufr.obs_builder import add_main_functions
@@ -14,12 +15,21 @@ MAPPING_PATH = map_path('prepbufr_adpsfc.yaml')
 # Number of temperature event levels read from YAML
 NUM_T_EVENTS = 5
 
-# Flag to mimi GSI's TSENSIBLE option. 
-# True: Use sensible/dry temperature (Tdry) by searching through event stack
-# False: Use Tv if available (TPC=8), otherwise Tdry (TPC 1-7), 
-#        for testing against GSI only.
-TSENSIBLE = True
+# - If ObsType/virtualTemperature is in the encoder variables, use Tv if available otherwise Tdry.
+#   This option mimics the GSI's TSENSIBLE=False default
+# - If ObsType/virtualTemperature not in encoder variables, always use Tdry
+#   This is what we want to do long-term
 
+# obs types 181, 183, 187 (land stations) always use Tdry to match GSI behavior
+TSENSIBLE_EXCEPTION_TYPES = [181, 183, 187]
+
+
+def _check_include_tv(yaml_path):
+    """Check if virtualTemperature should be included based on encoder variables in YAML."""
+    with open(yaml_path, 'r') as f:
+        config = yaml.safe_load(f)
+    encoder_vars = config.get('encoder', {}).get('variables', [])
+    return any(v.get('name') == 'ObsType/virtualTemperature' for v in encoder_vars)
 
 class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
     def __init__(self):
@@ -102,9 +112,14 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
         sequenceNum = np.zeros(dhr.shape, dtype=np.int32)
         self.log.debug(f' sequenceNum min/max =  {sequenceNum.min()} {sequenceNum.max()}')
 
-        self.log.debug(f'Extract temperature from event stack (tsensible={TSENSIBLE})')
+        include_tv = _check_include_tv(MAPPING_PATH)
+        self.log.debug(f'Extract temperature from event stack (include_tv={include_tv})')
 
-        # Get temperature data from all event levels
+        # get record-specific data
+        toboe = container.get('airTemperatureObsError')
+        obs_type = container.get('observationType')
+
+        # get event-specific data
         tpc_events = []
         tob_events = []
         tqm_events = []
@@ -113,15 +128,14 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
             tob_events.append(container.get(f'temperatureOb{i}'))
             tqm_events.append(container.get(f'temperatureQM{i}'))
 
-        # Get ObsError (from T__BACKG, not event-specific)
-        toboe = container.get('airTemperatureObsError')
+        # get paths for adding new variables
+        tob_paths = container.get_paths('temperatureOb1')
 
-        # Get fill values from each variable type
+        # create arrays with fill_value
         tob_fill = tob_events[0].fill_value
         tqm_fill = tqm_events[0].fill_value
         toe_fill = toboe.fill_value
 
-        # Initialize output arrays with appropriate fill values
         n_obs = tob_events[0].shape[0]
         tsen = np.full(n_obs, tob_fill)
         tsenqm = np.full(n_obs, tqm_fill)
@@ -130,18 +144,21 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
         tvoqm = np.full(n_obs, tqm_fill)
         tvooe = np.full(n_obs, toe_fill)
 
-        # Search through events for each observation
+        # loop through obs
         for idx in range(n_obs):
+            use_tv = include_tv and (int(obs_type[idx]) not in TSENSIBLE_EXCEPTION_TYPES)
+
+            # look back through events for desired T field
             for ev in range(NUM_T_EVENTS):
                 tpc_val = tpc_events[ev][idx]
                 tob_val = tob_events[ev][idx]
                 tqm_val = tqm_events[ev][idx]
 
-                # Skip if obs masked/missing
                 if ma.is_masked(tpc_val) or ma.is_masked(tob_val):
                     continue
 
-                if tpc_val == 8 and ( not TSENSIBLE ):
+                # select desired obs type, if present 
+                if tpc_val == 8 and use_tv:
                     # use Tv if available
                     tvo[idx] = tob_val
                     tvoqm[idx] = tqm_val
@@ -155,18 +172,19 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
                     break
 
         self.log.debug(f'Update variables in container')
-        container.replace('airTemperatureObsValue', tsen)
-        container.replace('airTemperatureQualityMarker', tsenqm)
+        container.add('airTemperatureObsValue', tsen, tob_paths)
+        container.add('airTemperatureQualityMarker', tsenqm, tob_paths)
         container.replace('airTemperatureObsError', tsenoe)
-        container.replace('virtualTemperatureObsValue', tvo)
-        container.replace('virtualTemperatureQualityMarker', tvoqm)
-        container.replace('virtualTemperatureObsError', tvooe)
+
+        if include_tv:
+            container.add('virtualTemperatureObsValue', tvo, tob_paths)
+            container.add('virtualTemperatureQualityMarker', tvoqm, tob_paths)
+            container.add('virtualTemperatureObsError', tvooe, tob_paths)
 
         self.log.debug(f'Add variables to container')
         container.add('sequenceNumber', sequenceNum, dhr_paths)
         container.add('obsSubType', sequenceNum, dhr_paths)
 
-        # Check
         self.log.debug(f'container list (updated): {container.list()}')
 
         return container

--- a/dump/scripts/atmosphere/prepbufr_adpsfc.py
+++ b/dump/scripts/atmosphere/prepbufr_adpsfc.py
@@ -20,7 +20,7 @@ NUM_T_EVENTS = 5
 # - If ObsType/virtualTemperature not in encoder variables, always use Tdry
 #   This is what we want to do long-term
 
-# obs types 181, 183 (land stations) always use Tdry to match GSI behavior
+# obs types 181, 187 (land stations) always use Tdry to match GSI behavior
 TSENSIBLE_EXCEPTION_TYPES = [181, 187]
 
 


### PR DESCRIPTION
The (hard-coded) default in the GSI is to have Tsensible=False in read_prepbufr. 
This option results in virtual temperature observations being selected in they are present for a given record, otherwise we use Tdry (sensible). There is an exception for land station obs (Metar, SYNOP), which always use Tdry regardless of the Tsensible flag. 

In the future, it would be prefrable to switch to using Tdry for all conventional T obs (so, Tsensible=True in the GSI).

This PR: 
-adds the option to choose between the GSIs two Tsensible options.
-updates the Tsensible=False option to exclude the land station obs, as in the GSI.

To select Tsensible = False, and use virtual Temps where they are available, virtual temperature (and it's associated metadata fields should be listed as output in the mapping yaml). The default yaml has these settings. I've also added a second yaml for the Tsensible=True option. 

Resolves issue [104](https://github.com/NOAA-EMC/spoc/issues/104)

Testing: 
With the GSI's reject list not used, and the GSI obs-terrain correction turned off: 
-the new code reproduces the sfc station obs (adpsfc, sfcshp) from the GSI diag file for both Tvirtual and Tdry, with both options, within round-off error (10^(-5))
-new (and old code) matches the number of stations, excepting a station at the Sth Pole not in GSI. 
-the stats for the difference between the IODA and GSI diag file for the sonde obs are unchanged by this PR 



