### PR TITLE
Refine AMSR2 radiance configuration

### DIFF
--- a/dump/config/atmosphere/radiance_amsr2.yaml
+++ b/dump/config/atmosphere/radiance_amsr2.yaml
@@ -43,20 +43,12 @@ bufr:
     fieldOfViewNumber:
       query: '*/FOVN'
 
-    sensorScanAngle:
-      sensorScanAngle:
-        fieldOfViewNumber: '*/FOVN'
-        scanStart: -48.333
-        scanStep: 3.333
-        sensor: amsr2
-
 encoder:
   backend: netcdf
 
   dimensions:
   - name: Channel
     path: '*/AMSR2CHN'
-#    source: variables/sensorChannelNumber
 
   globals:
   - name: platformCommonName
@@ -104,7 +96,7 @@ encoder:
       source: variables/solarElevation
       longName: "SOLAR ELEVATION"
 
-    - name: "MetaData/sensorViewAngle"
+    - name: "MetaData/sensorZenithAngle"
       longName: "INCIDENCE ANGLE"
       source: variables/incidenceAngle
       units: "degree"


### PR DESCRIPTION
This PR updates the AMSR2 radiance YAML to match current obsForge and UFO expectations.
Changes include:
- Corrected the variable name for sensorZenithAngle
- Removed ScanAngle, since JEDI/UFO automatically derives the appropriate zenith angle when scan angle is not present in the IODA output
