### PR TITLE
Rename station T and q from adpsfc to be "At2M"

### DIFF
--- a/dump/config/atmosphere/prepbufr_adpsfc.yaml
+++ b/dump/config/atmosphere/prepbufr_adpsfc.yaml
@@ -126,7 +126,7 @@ bufr:
         - scale: 100
     airTemperatureObsError:
       query: "*/T___INFO/T__BACKG/TOE"
-    relativeHumidityObsError:
+    specificHumidityObsError:
       query: "*/Q___INFO/Q__BACKG/QOE"
       transforms:
         - scale: 0.1
@@ -322,8 +322,8 @@ encoder:
       units: "K"
 
     - name: "ObsError/specificHumidityAt2M"
-      source: variables/relativeHumidityObsError
-      longName: "Relative Humidity at 2m Error"
+      source: variables/specificHumidityObsError
+      longName: "Specific Humidity at 2m Error"
       units: "1"
 
     - name: "ObsError/windEastward"

--- a/dump/config/atmosphere/prepbufr_adpsfc.yaml
+++ b/dump/config/atmosphere/prepbufr_adpsfc.yaml
@@ -126,7 +126,7 @@ bufr:
         - scale: 100
     airTemperatureObsError:
       query: "*/T___INFO/T__BACKG/TOE"
-    specificHumidityObsError:
+    relativeHumidityObsError:
       query: "*/Q___INFO/Q__BACKG/QOE"
       transforms:
         - scale: 0.1
@@ -321,8 +321,10 @@ encoder:
       longName: "Virtual Temperature at 2m Error"
       units: "K"
 
+    # note: in the PREPBUFR, this is specified in RH units
+    # will need to be cleaned up.
     - name: "ObsError/specificHumidityAt2M"
-      source: variables/specificHumidityObsError
+      source: variables/relativeHumidityObsError
       longName: "Specific Humidity at 2m Error"
       units: "1"
 

--- a/dump/config/atmosphere/prepbufr_adpsfc.yaml
+++ b/dump/config/atmosphere/prepbufr_adpsfc.yaml
@@ -174,17 +174,17 @@ encoder:
       source: variables/observationType
       longName: "Station Pressure ObsType"
 
-    - name: "ObsType/airTemperature"
+    - name: "ObsType/airTemperatureAt2M"
       source: variables/observationType
-      longName: "airTemperature ObsType"
+      longName: "Air Temperature at 2m ObsType"
 
-    - name: "ObsType/virtualTemperature"
+    - name: "ObsType/virtualTemperatureAt2M"
       source: variables/observationType
-      longName: "virtualTemperature ObsType"
+      longName: "Virtual Temperature at 2m ObsType"
 
-    - name: "ObsType/specificHumidity"
+    - name: "ObsType/specificHumidityAt2M"
       source: variables/observationType
-      longName: "Specific Humidity ObsType"
+      longName: "Specific Humidity at 2m ObsType"
 
     - name: "ObsType/windEastward"
       source: variables/observationType
@@ -255,19 +255,19 @@ encoder:
       longName: "Station Pressure"
       units: "Pa"
 
-    - name: "ObsValue/airTemperature"
+    - name: "ObsValue/airTemperatureAt2M"
       source: variables/airTemperatureObsValue
-      longName: "airTemperature"
+      longName: "Air Temperature at 2m"
       units: "K"
 
-    - name: "ObsValue/virtualTemperature"
+    - name: "ObsValue/virtualTemperatureAt2M"
       source: variables/virtualTemperatureObsValue
-      longName: "virtualTemperature"
+      longName: "Virtual Temperature at 2m"
       units: "K"
 
-    - name: "ObsValue/specificHumidity"
+    - name: "ObsValue/specificHumidityAt2M"
       source: variables/specificHumidityObsValue
-      longName: "Specific Humidity"
+      longName: "Specific Humidity at 2m"
       units: "kg kg-1"
 
     - name: "ObsValue/windEastward"
@@ -285,17 +285,17 @@ encoder:
       source: variables/stationPressureQualityMarker
       longName: "Station Pressure Quality Marker"
 
-    - name: "QualityMarker/airTemperature"
+    - name: "QualityMarker/airTemperatureAt2M"
       source: variables/airTemperatureQualityMarker
-      longName: "airTemperature Quality Marker"
+      longName: "Air Temperature at 2m Quality Marker"
 
-    - name: "QualityMarker/virtualTemperature"
+    - name: "QualityMarker/virtualTemperatureAt2M"
       source: variables/virtualTemperatureQualityMarker
-      longName: "virtualTemperature Quality Marker"
+      longName: "Virtual Temperature at 2m Quality Marker"
 
-    - name: "QualityMarker/specificHumidity"
+    - name: "QualityMarker/specificHumidityAt2M"
       source: variables/specificHumidityQualityMarker
-      longName: "Specific Humidity Quality Marker"
+      longName: "Specific Humidity at 2m Quality Marker"
 
     - name: "QualityMarker/windEastward"
       source: variables/windEastwardQualityMarker
@@ -311,19 +311,19 @@ encoder:
       longName: "Station Pressure Error"
       units: "Pa"
 
-    - name: "ObsError/airTemperature"
+    - name: "ObsError/airTemperatureAt2M"
       source: variables/airTemperatureObsError
-      longName: "airTemperature Error"
+      longName: "Air Temperature at 2m Error"
       units: "K"
 
-    - name: "ObsError/virtualTemperature"
+    - name: "ObsError/virtualTemperatureAt2M"
       source: variables/virtualTemperatureObsError
-      longName: "virtualTemperature Error"
+      longName: "Virtual Temperature at 2m Error"
       units: "K"
 
-    - name: "ObsError/specificHumidity"
+    - name: "ObsError/specificHumidityAt2M"
       source: variables/relativeHumidityObsError
-      longName: "Relative Humidity Error"
+      longName: "Relative Humidity at 2m Error"
       units: "1"
 
     - name: "ObsError/windEastward"

--- a/dump/scripts/atmosphere/prepbufr_adpsfc.py
+++ b/dump/scripts/atmosphere/prepbufr_adpsfc.py
@@ -55,7 +55,7 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
                 'longName': 'Observation SubType',
             },
             {
-                'name': 'ObsSubType/specificHumidity',
+                'name': 'ObsSubType/specificHumidityAt2M',
                 'source': 'obsSubType',
                 'longName': 'Observation SubType',
             },

--- a/dump/scripts/atmosphere/prepbufr_adpsfc.py
+++ b/dump/scripts/atmosphere/prepbufr_adpsfc.py
@@ -25,11 +25,11 @@ TSENSIBLE_EXCEPTION_TYPES = [181, 187]
 
 
 def _check_include_tv(yaml_path):
-    """Check if virtualTemperature should be included based on encoder variables in YAML."""
+    """Check if virtualTemperatureAt2M should be included based on encoder variables in YAML."""
     with open(yaml_path, 'r') as f:
         config = yaml.safe_load(f)
     encoder_vars = config.get('encoder', {}).get('variables', [])
-    return any(v.get('name') == 'ObsType/virtualTemperature' for v in encoder_vars)
+    return any(v.get('name') == 'ObsType/virtualTemperatureAt2M' for v in encoder_vars)
 
 class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
     def __init__(self):
@@ -50,7 +50,7 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
                 'longName': 'Observation SubType',
             },
             {
-                'name': 'ObsSubType/airTemperature',
+                'name': 'ObsSubType/airTemperatureAt2M',
                 'source': 'obsSubType',
                 'longName': 'Observation SubType',
             },
@@ -73,7 +73,7 @@ class AdpsfcPrepbufrObsBuilder(PrepbufrObsBuilder):
 
         if _check_include_tv(MAPPING_PATH):
             variables.append({
-                'name': 'ObsSubType/virtualTemperature',
+                'name': 'ObsSubType/virtualTemperatureAt2M',
                 'source': 'obsSubType',
                 'longName': 'Observation SubType',
             })


### PR DESCRIPTION
The JEDI standard is for airTemperature and specificHumidity to refer to the atmospheric profile variable. 

This PR renames the adpsfc temp and humidity station observations in the output IODA files to specify that these are surface, and not profile, observations, by adding "At2M" to the end of each variable name. This naming is consistent with that used by other JEDI partners. 

It also replaces some incorrect references to relative humidity with "specific humidity".

